### PR TITLE
Checkbox

### DIFF
--- a/src/body.ts
+++ b/src/body.ts
@@ -1,3 +1,13 @@
 import { HTML } from "bigtest";
 
-export const Body = HTML.extend<HTMLBodyElement>("body").selector("body");
+export const Body = HTML.extend<HTMLBodyElement>("body")
+  .selector("body")
+  .actions({
+    click: ({ perform }) =>
+      perform((element) => {
+        if (document.activeElement && "blur" in document.activeElement) {
+          (document.activeElement as HTMLElement).blur();
+        }
+        element.click();
+      }),
+  });

--- a/src/body.ts
+++ b/src/body.ts
@@ -1,0 +1,3 @@
+import { HTML } from "bigtest";
+
+export const Body = HTML.extend<HTMLBodyElement>("body").selector("body");

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -1,9 +1,17 @@
 import { CheckBox } from "@bigtest/interactor";
 
-export const MaterialCheckbox = CheckBox.extend("MuiCheckbox").filters({
-  /**
-   * Checkbox component does not set the native input element to indeterminate due to inconsistent behavior across browsers.
-   * However, it set a data-indeterminate attribute on the input.
-   */
-  indeterminate: (element) => element.dataset.indeterminate === "true",
-});
+export const MaterialCheckbox = CheckBox.extend("MUI Checkbox")
+  .filters({
+    /**
+     * Checkbox component does not set the native input element to indeterminate due to inconsistent behavior across browsers.
+     * However, it set a data-indeterminate attribute on the input.
+     */
+    indeterminate: (element) => element.dataset.indeterminate === "true",
+  })
+  .actions({
+    click: ({ perform }) =>
+      perform((element) => {
+        element.focus();
+        element.click();
+      }),
+  });

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -1,0 +1,5 @@
+import { CheckBox } from "@bigtest/interactor";
+
+export const MaterialCheckbox = CheckBox.extend("material-ui checkbox").filters({
+  indeterminate: (element) => element.dataset.indeterminate === "true",
+});

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -1,5 +1,9 @@
 import { CheckBox } from "@bigtest/interactor";
 
-export const MaterialCheckbox = CheckBox.extend("material-ui checkbox").filters({
+export const MaterialCheckbox = CheckBox.extend("MuiCheckbox").filters({
+  /**
+   * Checkbox component does not set the native input element to indeterminate due to inconsistent behavior across browsers.
+   * However, it set a data-indeterminate attribute on the input.
+   */
   indeterminate: (element) => element.dataset.indeterminate === "true",
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export { Button } from '@bigtest/interactor'
+export { Button } from "@bigtest/interactor";
+export { MaterialCheckbox as CheckBox } from "./checkbox";
+export { Body } from "./body";

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -1,0 +1,102 @@
+import { test, Page } from "bigtest";
+import { Body, CheckBox as Interactor } from "../src/index";
+import { Checkbox, FormControlLabel } from "@material-ui/core";
+import { render } from "./helpers";
+
+export default test("Checkbox")
+  .step(Page.visit("/"))
+  .child("filter", (test) =>
+    test
+      .child("by locator", (test) =>
+        test
+          .step("render", () => render(<FormControlLabel label="locator" control={<Checkbox />} />))
+          .assertion(Interactor("locator").exists())
+      )
+      .child("by checked", (test) =>
+        test
+          .step("render", () => render(<FormControlLabel label="checked" checked control={<Checkbox />} />))
+          .assertion(Interactor({ checked: true }).exists())
+      )
+      .child("by indeterminate", (test) =>
+        test
+          .step("render", () => render(<FormControlLabel label="indeterminate" control={<Checkbox indeterminate />} />))
+          .assertion(Interactor({ indeterminate: true }).exists())
+      )
+      .child("by disabled", (test) =>
+        test
+          .step("render", () => render(<FormControlLabel label="disabled" disabled control={<Checkbox />} />))
+          .assertion(Interactor({ disabled: true }).exists())
+      )
+      .child("by visible", (test) =>
+        test.step("render", () => render(<Checkbox />)).assertion(Interactor({ visible: false }).exists())
+      )
+  )
+  .child("click", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
+      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: false, focused: false })))
+      .child("click", (test) =>
+        test
+          .step("click", () => Interactor("checkbox").click())
+          // TODO `focused` doesn't set :(
+          .assertion(Interactor("checkbox").is({ checked: true /*, focused: true */ }))
+      )
+  )
+  .child("focus", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
+      .child("default", (test) => test.assertion(Interactor("checkbox").is({ focused: false })))
+      .child("focus", (test) =>
+        test.step("focus", () => Interactor("checkbox").focus()).assertion(Interactor("checkbox").is({ focused: true }))
+      )
+  )
+  .child("blur", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox autoFocus />} />))
+      .child("default", (test) => test.assertion(Interactor("checkbox").is({ focused: true })))
+      .child("blur", (test) =>
+        test.step("blur", () => Interactor("checkbox").blur()).assertion(Interactor("checkbox").is({ focused: false }))
+      )
+  )
+  .child("check", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
+      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: false })))
+      .child("check", (test) =>
+        test.step("check", () => Interactor("checkbox").check()).assertion(Interactor("checkbox").is({ checked: true }))
+      )
+  )
+  .child("uncheck", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox defaultChecked />} />))
+      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: true })))
+      .child("uncheck", (test) =>
+        test
+          .step("uncheck", () => Interactor("checkbox").uncheck())
+          .assertion(Interactor("checkbox").is({ checked: false }))
+      )
+  )
+  .child("toggle", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
+      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: false })))
+      .child("toggle 1", (test) =>
+        test
+          .step("toggle", () => Interactor("checkbox").toggle())
+          .assertion(Interactor("checkbox").is({ checked: true }))
+      )
+      .child("toggle 2", (test) =>
+        test
+          .step("toggle", () => Interactor("checkbox").toggle())
+          .step("toggle", () => Interactor("checkbox").toggle())
+          .assertion(Interactor("checkbox").is({ checked: false }))
+      )
+  );
+// TODO Don't work because `click` doesn't affect to `document.activeElement`
+// .child("click out side", (test) =>
+//   test
+//     .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
+//     .step("focus", () => Interactor("checkbox").focus())
+//     .step("focus the body", () => Body().click())
+//     .assertion(Interactor("checkbox").is({ focused: false }))
+// );

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -5,91 +5,82 @@ import { render } from "./helpers";
 
 export default test("Checkbox")
   .step(Page.visit("/"))
-  .child("filter", (test) =>
+  .child("test `filter` by locator", (test) =>
     test
-      .child("by locator", (test) =>
-        test
-          .step("render", () => render(<FormControlLabel label="locator" control={<Checkbox />} />))
-          .assertion(Interactor("locator").exists())
-      )
-      .child("by checked", (test) =>
-        test
-          .step("render", () => render(<FormControlLabel label="checked" checked control={<Checkbox />} />))
-          .assertion(Interactor({ checked: true }).exists())
-      )
-      .child("by indeterminate", (test) =>
-        test
-          .step("render", () => render(<FormControlLabel label="indeterminate" control={<Checkbox indeterminate />} />))
-          .assertion(Interactor({ indeterminate: true }).exists())
-      )
-      .child("by disabled", (test) =>
-        test
-          .step("render", () => render(<FormControlLabel label="disabled" disabled control={<Checkbox />} />))
-          .assertion(Interactor({ disabled: true }).exists())
-      )
-      .child("by visible", (test) =>
-        test.step("render", () => render(<Checkbox />)).assertion(Interactor({ visible: false }).exists())
-      )
+      .step("render", () => render(<FormControlLabel label="locator" control={<Checkbox />} />))
+      .assertion(Interactor().exists())
   )
-  .child("click", (test) =>
+  .child("test `filter` by checked", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checked" checked control={<Checkbox />} />))
+      .assertion(Interactor({ checked: true }).exists())
+  )
+  .child("test `filter` by indeterminate", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="indeterminate" control={<Checkbox indeterminate />} />))
+      .assertion(Interactor({ indeterminate: true }).exists())
+  )
+  .child("test `filter` by disabled", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="disabled" disabled control={<Checkbox />} />))
+      .assertion(Interactor({ disabled: true }).exists())
+  )
+  .child("test `filter` by visible", (test) =>
+    test.step("render", () => render(<Checkbox />)).assertion(Interactor({ visible: false }).exists())
+  )
+  .child("test `click` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: false, focused: false })))
-      .child("click", (test) =>
+      .assertion(Interactor().is({ checked: false, focused: false }))
+      .child("click and assert", (test) =>
         test
-          .step("click", () => Interactor("checkbox").click())
+          .step(Interactor().click())
           // TODO `focused` doesn't set :(
-          .assertion(Interactor("checkbox").is({ checked: true /*, focused: true */ }))
+          .assertion(Interactor().is({ checked: true /*, focused: true */ }))
       )
   )
-  .child("focus", (test) =>
+  .child("test `focus` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .child("default", (test) => test.assertion(Interactor("checkbox").is({ focused: false })))
-      .child("focus", (test) =>
-        test.step("focus", () => Interactor("checkbox").focus()).assertion(Interactor("checkbox").is({ focused: true }))
+      .assertion(Interactor().is({ focused: false }))
+      .child("focus and assert", (test) =>
+        test.step(Interactor().focus()).assertion(Interactor().is({ focused: true }))
       )
   )
-  .child("blur", (test) =>
+  .child("test `blur` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox autoFocus />} />))
-      .child("default", (test) => test.assertion(Interactor("checkbox").is({ focused: true })))
-      .child("blur", (test) =>
-        test.step("blur", () => Interactor("checkbox").blur()).assertion(Interactor("checkbox").is({ focused: false }))
-      )
+      .assertion(Interactor().is({ focused: true }))
+      .child("blur and assert", (test) => test.step(Interactor().blur()).assertion(Interactor().is({ focused: false })))
   )
-  .child("check", (test) =>
+  .child("test `check` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: false })))
-      .child("check", (test) =>
-        test.step("check", () => Interactor("checkbox").check()).assertion(Interactor("checkbox").is({ checked: true }))
+      .assertion(Interactor().is({ checked: false }))
+      .child("check and assert", (test) =>
+        test.step(Interactor().check()).assertion(Interactor().is({ checked: true }))
       )
   )
-  .child("uncheck", (test) =>
+  .child("test `uncheck` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox defaultChecked />} />))
-      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: true })))
-      .child("uncheck", (test) =>
-        test
-          .step("uncheck", () => Interactor("checkbox").uncheck())
-          .assertion(Interactor("checkbox").is({ checked: false }))
+      .assertion(Interactor().is({ checked: true }))
+      .child("uncheck and assert", (test) =>
+        test.step(Interactor().uncheck()).assertion(Interactor().is({ checked: false }))
       )
   )
-  .child("toggle", (test) =>
+  // NOTE: Here is nice example of duplicating tests by useless parallelism
+  .child("test `toggle` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .child("default", (test) => test.assertion(Interactor("checkbox").is({ checked: false })))
-      .child("toggle 1", (test) =>
+      .assertion(Interactor().is({ checked: false }))
+      .child("toggle twice", (test) =>
         test
-          .step("toggle", () => Interactor("checkbox").toggle())
-          .assertion(Interactor("checkbox").is({ checked: true }))
-      )
-      .child("toggle 2", (test) =>
-        test
-          .step("toggle", () => Interactor("checkbox").toggle())
-          .step("toggle", () => Interactor("checkbox").toggle())
-          .assertion(Interactor("checkbox").is({ checked: false }))
+          .step(Interactor().toggle())
+          .assertion(Interactor().is({ checked: true }))
+          .child("second toggle", (test) =>
+            test.step(Interactor().toggle()).assertion(Interactor().is({ checked: false }))
+          )
       )
   );
 // TODO Don't work because `click` doesn't affect to `document.activeElement`

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -1,93 +1,81 @@
 import { test, Page } from "bigtest";
-import { Body, CheckBox as Interactor } from "../src/index";
-import { Checkbox, FormControlLabel } from "@material-ui/core";
+import { Body, CheckBox } from "../src/index";
+import { Checkbox as Component, FormControlLabel } from "@material-ui/core";
 import { render } from "./helpers";
 
 export default test("Checkbox")
   .step(Page.visit("/"))
   .child("test `filter` by locator", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="locator" control={<Checkbox />} />))
-      .assertion(Interactor().exists())
+      .step("render", () => render(<FormControlLabel label="locator" control={<Component />} />))
+      .assertion(CheckBox("locator").exists())
   )
   .child("test `filter` by checked", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checked" checked control={<Checkbox />} />))
-      .assertion(Interactor({ checked: true }).exists())
+      .step("render", () => render(<FormControlLabel label="checked" checked control={<Component />} />))
+      .assertion(CheckBox({ checked: true }).exists())
   )
   .child("test `filter` by indeterminate", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="indeterminate" control={<Checkbox indeterminate />} />))
-      .assertion(Interactor({ indeterminate: true }).exists())
+      .step("render", () => render(<FormControlLabel label="indeterminate" control={<Component indeterminate />} />))
+      .assertion(CheckBox({ indeterminate: true }).exists())
   )
   .child("test `filter` by disabled", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="disabled" disabled control={<Checkbox />} />))
-      .assertion(Interactor({ disabled: true }).exists())
+      .step("render", () => render(<FormControlLabel label="disabled" disabled control={<Component />} />))
+      .assertion(CheckBox({ disabled: true }).exists())
   )
   .child("test `filter` by visible", (test) =>
-    test.step("render", () => render(<Checkbox />)).assertion(Interactor({ visible: false }).exists())
+    test.step("render", () => render(<Component />)).assertion(CheckBox({ visible: false }).exists())
   )
   .child("test `click` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .assertion(Interactor().is({ checked: false, focused: false }))
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .assertion(CheckBox().is({ checked: false, focused: false }))
       .child("click and assert", (test) =>
-        test
-          .step(Interactor().click())
-          // TODO `focused` doesn't set :(
-          .assertion(Interactor().is({ checked: true /*, focused: true */ }))
+        test.step(CheckBox().click()).assertion(CheckBox().is({ checked: true, focused: true }))
       )
   )
   .child("test `focus` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .assertion(Interactor().is({ focused: false }))
-      .child("focus and assert", (test) =>
-        test.step(Interactor().focus()).assertion(Interactor().is({ focused: true }))
-      )
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .assertion(CheckBox().is({ focused: false }))
+      .child("focus and assert", (test) => test.step(CheckBox().focus()).assertion(CheckBox().is({ focused: true })))
   )
   .child("test `blur` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox autoFocus />} />))
-      .assertion(Interactor().is({ focused: true }))
-      .child("blur and assert", (test) => test.step(Interactor().blur()).assertion(Interactor().is({ focused: false })))
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
+      .assertion(CheckBox().is({ focused: true }))
+      .child("blur and assert", (test) => test.step(CheckBox().blur()).assertion(CheckBox().is({ focused: false })))
   )
   .child("test `check` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .assertion(Interactor().is({ checked: false }))
-      .child("check and assert", (test) =>
-        test.step(Interactor().check()).assertion(Interactor().is({ checked: true }))
-      )
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .assertion(CheckBox().is({ checked: false }))
+      .child("check and assert", (test) => test.step(CheckBox().check()).assertion(CheckBox().is({ checked: true })))
   )
   .child("test `uncheck` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox defaultChecked />} />))
-      .assertion(Interactor().is({ checked: true }))
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component defaultChecked />} />))
+      .assertion(CheckBox().is({ checked: true }))
       .child("uncheck and assert", (test) =>
-        test.step(Interactor().uncheck()).assertion(Interactor().is({ checked: false }))
+        test.step(CheckBox().uncheck()).assertion(CheckBox().is({ checked: false }))
       )
   )
-  // NOTE: Here is nice example of duplicating tests by useless parallelism
   .child("test `toggle` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-      .assertion(Interactor().is({ checked: false }))
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .assertion(CheckBox().is({ checked: false }))
       .child("toggle twice", (test) =>
         test
-          .step(Interactor().toggle())
-          .assertion(Interactor().is({ checked: true }))
-          .child("second toggle", (test) =>
-            test.step(Interactor().toggle()).assertion(Interactor().is({ checked: false }))
-          )
+          .step(CheckBox().toggle())
+          .assertion(CheckBox().is({ checked: true }))
+          .child("second toggle", (test) => test.step(CheckBox().toggle()).assertion(CheckBox().is({ checked: false })))
       )
+  )
+  .child("test click outside", (test) =>
+    test
+      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
+      .step("click to the body", () => Body().click())
+      .assertion(CheckBox().is({ focused: false }))
   );
-// TODO Don't work because `click` doesn't affect to `document.activeElement`
-// .child("click out side", (test) =>
-//   test
-//     .step("render", () => render(<FormControlLabel label="checkbox" control={<Checkbox />} />))
-//     .step("focus", () => Interactor("checkbox").focus())
-//     .step("focus the body", () => Body().click())
-//     .assertion(Interactor("checkbox").is({ focused: false }))
-// );


### PR DESCRIPTION
## Issues
- ~~The `click` action doesn't set `focused` to true~~ Made workaround for now

## Find usages for these props
- `required`
- `size`
- `value`

## Questions

- Should we place `indeterminate` filter to the base Checkbox interactor? Fixed in https://github.com/thefrontside/bigtest/pull/909
- Should we support the `aria-label`, `aria-labelledby`, `title` attributes as fallback locator to all base interactors?
- Do we need to add the [Fieldset](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset) interactor?
- How to test the validity filter?