### PR TITLE
DRAFT DateTimePicker Interactors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,6 +1405,19 @@
         "node-fetch": "^2.6.1"
       }
     },
+    "@date-io/core": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-1.3.13.tgz",
+      "integrity": "sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA=="
+    },
+    "@date-io/date-fns": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-1.3.13.tgz",
+      "integrity": "sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==",
+      "requires": {
+        "@date-io/core": "^1.3.13"
+      }
+    },
     "@effection/channel": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/@effection/channel/-/channel-0.6.8.tgz",
@@ -1537,6 +1550,19 @@
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0 || ^17.0.0",
         "react-transition-group": "^4.4.0"
+      }
+    },
+    "@material-ui/pickers": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.3.10.tgz",
+      "integrity": "sha512-hS4pxwn1ZGXVkmgD4tpFpaumUaAg2ZzbTrxltfC5yPw4BJV+mGkfnQOB4VpWEYZw2jv65Z0wLwDE/piQiPPZ3w==",
+      "requires": {
+        "@babel/runtime": "^7.6.0",
+        "@date-io/core": "1.x",
+        "@types/styled-jsx": "^2.2.8",
+        "clsx": "^1.0.2",
+        "react-transition-group": "^4.0.0",
+        "rifm": "^0.7.0"
       }
     },
     "@material-ui/styles": {
@@ -2247,6 +2273,14 @@
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
+      }
+    },
+    "@types/styled-jsx": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@types/styled-jsx/-/styled-jsx-2.2.8.tgz",
+      "integrity": "sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==",
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/ws": {
@@ -4369,6 +4403,11 @@
         "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
+      "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg=="
     },
     "deasync": {
       "version": "0.1.21",
@@ -10487,6 +10526,14 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
+    },
+    "rifm": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rifm/-/rifm-0.7.0.tgz",
+      "integrity": "sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      }
     },
     "rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
   },
   "dependencies": {
     "@bigtest/interactor": "^0.28.2",
+    "@date-io/date-fns": "^1.3.13",
     "@material-ui/core": "^4.11.3",
+    "@material-ui/pickers": "^3.3.10",
     "@material-ui/styles": "^4.11.3",
-    "@testing-library/react": "^11.2.5"
+    "@testing-library/react": "^11.2.5",
+    "date-fns": "^2.19.0"
   }
 }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -29,6 +29,11 @@ function calendarLocator(element: HTMLElement) {
   return [selectedDay, header].filter(Boolean).join(" ");
 }
 
+export const getDay = (element: HTMLElement) => {
+  const text = getSelectedElement(element)?.innerText;
+  const day = text ? parseInt(text) : NaN;
+  return Number.isNaN(day) ? undefined : day;
+};
 export const getMonth = (element: HTMLElement) => getTitleElement(element)?.innerText.replace(/\s[0-9]{4}$/, "");
 export const getYear = (element: HTMLElement) => getTitleElement(element)?.innerText.replace(/.*\s([0-9]{4})$/, "$1");
 
@@ -154,11 +159,7 @@ export const Calendar = createInteractor<HTMLElement>("MUI Calendar")
   .filters({
     year: getYear,
     month: getMonth,
-    day: (element) => {
-      const text = getSelectedElement(element)?.innerText;
-      const day = text ? parseInt(text) : NaN;
-      return Number.isNaN(day) ? undefined : day;
-    },
+    day: getDay,
     title: (element) => getTitleElement(element)?.innerText,
     weekDay: (element) => {
       const rootDayElement = getSelectedElement(element)?.parentElement;

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -1,4 +1,4 @@
-import { createInteractor, HTML } from "bigtest";
+import { createInteractor, HTML, including, not } from "bigtest";
 import { isHTMLElement } from "../test/helpers";
 
 function getHeaderElement(element: HTMLElement) {
@@ -57,5 +57,18 @@ export const Calendar = createInteractor<HTMLElement>("MUI Calendar")
         const prevMonthElement = getHeaderElement(element)?.firstElementChild;
         if (isHTMLElement(prevMonthElement)) prevMonthElement.click();
       }),
-    selectDay: (interactor, day: number) => interactor.find(HTML.selector(".MuiPickersDay-day")(String(day))).click(),
+    selectDay: async (interactor, day: number) => {
+      const dayInteractor = await interactor.find(
+        HTML.selector(".MuiPickersCalendar-week > [role='presentation']")(String(day))
+      );
+      // TODO We need better message for that
+      // await dayInteractor.has({ className: not(including("MuiPickersDay-dayDisabled")) });
+      // Instead of
+      /*
+        │ ╒═ Filter:   className
+        │ ├─ Expected: not including "MuiPickersDay-dayDisabled"
+        │ └─ Received: "MuiButtonBase-root MuiIconButton-root MuiPickersDay-day MuiPickersDay-dayDisabled"
+      */
+      await dayInteractor.click();
+    },
   });

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -144,9 +144,4 @@ export const Calendar = createInteractor<HTMLElement>("MUI Calendar")
     setYear: goToYear,
     setMonth: goToMonth,
     setDay: goToDay,
-    setDate: async (interactor, targetDate: { day: number; month: string; year: number }) => {
-      await goToYear(interactor, targetDate.year);
-      await goToMonth(interactor, targetDate.month);
-      await goToDay(interactor, targetDate.day);
-    },
   });

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -25,16 +25,86 @@ export const getMonth = (element: HTMLElement) => getTitleElement(element)?.inne
 export const getYear = (element: HTMLElement) => getTitleElement(element)?.innerText.replace(/.*\s([0-9]{4})$/, "$1");
 
 function getCurrentMonth(interactor: Interactor<HTMLElement, any>) {
-  return new Promise((resolve) => interactor.perform((element) => resolve(getMonth(element))));
+  return new Promise<string | undefined>((resolve) => interactor.perform((element) => resolve(getMonth(element))));
 }
 function getCurrentYear(interactor: Interactor<HTMLElement, any>) {
-  return new Promise((resolve) =>
+  return new Promise<number | undefined>((resolve) =>
     interactor.perform((element) => {
       const yearString = getYear(element);
       const year = yearString ? parseInt(yearString) : NaN;
       resolve(Number.isNaN(year) ? undefined : year);
     })
   );
+}
+function goToNextMonth({ perform }: Interactor<HTMLElement, any>) {
+  return perform((element) => {
+    // NOTE: We can't go upwards by using `Interactor().find(...)`
+    const nextMonthElement = getHeaderElement(element)?.lastElementChild;
+    if (isHTMLElement(nextMonthElement)) nextMonthElement.click();
+  });
+}
+function goToPrevMonth({ perform }: Interactor<HTMLElement, any>) {
+  return perform((element) => {
+    // NOTE: We can't go upwards by using `Interactor().find(...)`
+    const prevMonthElement = getHeaderElement(element)?.firstElementChild;
+    if (isHTMLElement(prevMonthElement)) prevMonthElement.click();
+  });
+}
+
+async function goToYear(interactor: Interactor<HTMLElement, any>, targetYear: number) {
+  let currentMonth = await getCurrentMonth(interactor);
+  let currentYear = await getCurrentYear(interactor);
+
+  if (!currentMonth || !currentYear) throw new Error("Can't get current month and year");
+  if (currentYear == targetYear) return;
+  const step = currentYear < targetYear ? () => goToNextMonth(interactor) : () => goToPrevMonth(interactor);
+  const targetMonth = currentMonth;
+  while (currentYear != targetYear || currentMonth != targetMonth) {
+    await step();
+    const prevMonth: string | undefined = currentMonth;
+    currentMonth = await getCurrentMonth(interactor);
+    currentYear = await getCurrentYear(interactor);
+    if (prevMonth == currentMonth)
+      throw new Error(
+        `Can't set '${targetYear}' year. It might happened because of 'minDate/maxDate' or 'disableFuture/disablePast' props`
+      );
+  }
+}
+async function goToMonth(interactor: Interactor<HTMLElement, any>, targetMonth: string) {
+  let directions = [() => goToPrevMonth(interactor), () => goToNextMonth(interactor)];
+  directions = Math.round(Math.random()) ? directions : directions.reverse();
+  let currentMonth = await getCurrentMonth(interactor);
+  let currentYear = await getCurrentYear(interactor);
+
+  if (!currentMonth || !currentYear) throw new Error("Can't get current month and year");
+  if (currentMonth == targetMonth) return;
+
+  const targetYear = currentYear;
+  let direction = directions.shift();
+  while (currentYear != targetYear || currentMonth != targetMonth) {
+    if (!direction)
+      throw new Error(
+        `Can't set '${targetMonth}' month. It might happened because of 'minDate/maxDate' or 'disableFuture/disablePast' props`
+      );
+    await direction();
+    const prevMonth = currentMonth;
+    currentMonth = await getCurrentMonth(interactor);
+    currentYear = await getCurrentYear(interactor);
+    if (currentYear != targetYear || currentMonth == prevMonth) direction = directions.shift();
+  }
+}
+function goToDay(interactor: Interactor<HTMLElement, any>, day: number) {
+  // NOTE: We can't find day if user has custom day render
+  const dayInteractor = interactor.find(HTML.selector(".MuiPickersCalendar-week > [role='presentation']")(String(day)));
+  // TODO We need better message for that
+  // await dayInteractor.has({ className: not(including("MuiPickersDay-dayDisabled")) });
+  // Instead of
+  /*
+      │ ╒═ Filter:   className
+      │ ├─ Expected: not including "MuiPickersDay-dayDisabled"
+      │ └─ Received: "MuiButtonBase-root MuiIconButton-root MuiPickersDay-day MuiPickersDay-dayDisabled"
+    */
+  return dayInteractor.click();
 }
 
 // TODO How do you think, do we need some actions/filters from the HTML interactor?
@@ -46,14 +116,14 @@ export const Calendar = createInteractor<HTMLElement>("MUI Calendar")
     return [selectedDay, header].filter(Boolean).join(" ");
   })
   .filters({
-    month: getMonth,
     year: getYear,
-    title: (element) => getTitleElement(element)?.innerText,
-    selectedDay: (element) => {
+    month: getMonth,
+    day: (element) => {
       const text = getSelectedElement(element)?.innerText;
       const day = text ? parseInt(text) : NaN;
       return Number.isNaN(day) ? undefined : day;
     },
+    title: (element) => getTitleElement(element)?.innerText,
     weekDay: (element) => {
       const rootDayElement = getSelectedElement(element)?.parentElement;
       const weekIndex = rootDayElement
@@ -64,75 +134,14 @@ export const Calendar = createInteractor<HTMLElement>("MUI Calendar")
     },
   })
   .actions({
-    nextMonth: ({ perform }) =>
-      perform((element) => {
-        // NOTE: We can't go upwards by using `Interactor().find(...)`
-        const nextMonthElement = getHeaderElement(element)?.lastElementChild;
-        if (isHTMLElement(nextMonthElement)) nextMonthElement.click();
-      }),
-    prevMonth: ({ perform }) =>
-      perform((element) => {
-        // NOTE: We can't go upwards by using `Interactor().find(...)`
-        const prevMonthElement = getHeaderElement(element)?.firstElementChild;
-        if (isHTMLElement(prevMonthElement)) prevMonthElement.click();
-      }),
-    setMonth: async (interactor, targetMonth: string) => {
-      //@ts-expect-error
-      let directions = [() => interactor.prevMonth(), () => interactor.nextMonth()];
-      directions = Math.round(Math.random()) ? directions : directions.reverse();
-      let currentMonth = await getCurrentMonth(interactor);
-      let currentYear = await getCurrentYear(interactor);
-
-      if (!currentMonth || !currentYear) return; // NOTE: Do we need throw error from here?
-      if (currentMonth == targetMonth) return;
-
-      const targetYear = currentYear;
-      let direction = directions.shift();
-      while (currentYear != targetYear || currentMonth != targetMonth) {
-        if (!direction)
-          throw new Error(
-            `Can't set '${targetMonth}' month. It might happened because of 'minDate/maxDate' or 'disableFuture/disablePast' props`
-          );
-        await direction();
-        const prevMonth = currentMonth;
-        currentMonth = await getCurrentMonth(interactor);
-        currentYear = await getCurrentYear(interactor);
-        if ((currentMonth == targetMonth && currentYear != targetYear) || currentMonth == prevMonth)
-          direction = directions.shift();
-      }
-    },
-    setYear: async (interactor, targetYear: number) => {
-      let currentMonth = await getCurrentMonth(interactor);
-      let currentYear = await getCurrentYear(interactor);
-
-      if (!currentMonth || !currentYear) return; // NOTE: Do we need throw error from here?
-      if (currentYear == targetYear) return;
-      //@ts-expect-error
-      const step = currentYear < targetYear ? () => interactor.nextMonth() : () => interactor.prevMonth();
-      const targetMonth = currentMonth;
-      while (currentYear != targetYear || currentMonth != targetMonth) {
-        await step();
-        const prevMonth = currentMonth;
-        currentMonth = await getCurrentMonth(interactor);
-        currentYear = await getCurrentYear(interactor);
-        if (prevMonth == currentMonth)
-          throw new Error(
-            `Can't set '${targetYear}' year. It might happened because of 'minDate/maxDate' or 'disableFuture/disablePast' props`
-          );
-      }
-    },
-    selectDay: (interactor, day: number) => {
-      const dayInteractor = interactor.find(
-        HTML.selector(".MuiPickersCalendar-week > [role='presentation']")(String(day))
-      );
-      // TODO We need better message for that
-      // await dayInteractor.has({ className: not(including("MuiPickersDay-dayDisabled")) });
-      // Instead of
-      /*
-        │ ╒═ Filter:   className
-        │ ├─ Expected: not including "MuiPickersDay-dayDisabled"
-        │ └─ Received: "MuiButtonBase-root MuiIconButton-root MuiPickersDay-day MuiPickersDay-dayDisabled"
-      */
-      return dayInteractor.click();
+    nextMonth: goToNextMonth,
+    prevMonth: goToPrevMonth,
+    setYear: goToYear,
+    setMonth: goToMonth,
+    setDay: goToDay,
+    setDate: async (interactor, targetDate: { day: number; month: string; year: number }) => {
+      await goToYear(interactor, targetDate.year);
+      await goToMonth(interactor, targetDate.month);
+      await goToDay(interactor, targetDate.day);
     },
   });

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -126,7 +126,11 @@ export const getCalendar = (utils: ReturnType<typeof useUtils>) =>
       const header = getTitleElement(element)?.innerText;
       const selectedDay = getSelectedElement(element)?.innerText;
       const monthAndYear = header ? utils.parse(header, "MMMM yyyy") : new Date();
-      return selectedDay ? utils.addDays(monthAndYear, parseInt(selectedDay)) : monthAndYear;
+      return new Date(
+        (selectedDay ? utils.addDays(monthAndYear, parseInt(selectedDay)) : monthAndYear)
+          ?.toISOString()
+          .replace(/T.*$/, "") ?? new Date()
+      );
     },
   }).actions({
     setMonth: async (interactor: Interactor<HTMLElement, any>, targetMonth: string) => {

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -1,7 +1,12 @@
-import { HTML } from "bigtest";
+import { createInteractor, HTML } from "bigtest";
 import { isHTMLElement } from "../test/helpers";
 
 function getHeaderElement(element: HTMLElement) {
+  const header = element.parentElement?.querySelector(".MuiPickersCalendarHeader-switchHeader");
+  return isHTMLElement(header) ? header : null;
+}
+
+function getTitleElement(element: HTMLElement) {
   const header = element.parentElement?.querySelector(".MuiPickersCalendarHeader-transitionContainer");
   return isHTMLElement(header) ? header : null;
 }
@@ -15,15 +20,16 @@ function getSelectedElement(element: HTMLElement) {
   const dayButton = element.querySelector(".MuiPickersDay-daySelected");
   return isHTMLElement(dayButton) ? dayButton : null;
 }
-export const Calendar = HTML.extend("MUI Calendar")
+
+export const Calendar = createInteractor<HTMLElement>("MUI Calendar")
   .selector(".MuiPickersCalendar-transitionContainer")
   .locator((element) => {
-    const header = getHeaderElement(element)?.innerText;
+    const header = getTitleElement(element)?.innerText;
     const selectedDay = getSelectedElement(element)?.innerText;
     return [selectedDay, header].filter(Boolean).join(" ");
   })
   .filters({
-    header: (element) => getHeaderElement(element)?.innerText,
+    title: (element) => getTitleElement(element)?.innerText,
     selectedDay: (element) => {
       const text = getSelectedElement(element)?.innerText;
       const day = text ? parseInt(text) : NaN;
@@ -39,7 +45,17 @@ export const Calendar = HTML.extend("MUI Calendar")
     },
   })
   .actions({
-    // TODO nextMonth
-    // TODO prevMonth
-    // TODO selectDay
+    nextMonth: ({ perform }) =>
+      perform((element) => {
+        // NOTE: We can't go upwards by using `Interactor().find(...)`
+        const nextMonthElement = getHeaderElement(element)?.lastElementChild;
+        if (isHTMLElement(nextMonthElement)) nextMonthElement.click();
+      }),
+    prevMonth: ({ perform }) =>
+      perform((element) => {
+        // NOTE: We can't go upwards by using `Interactor().find(...)`
+        const prevMonthElement = getHeaderElement(element)?.firstElementChild;
+        if (isHTMLElement(prevMonthElement)) prevMonthElement.click();
+      }),
+    selectDay: (interactor, day: number) => interactor.find(HTML.selector(".MuiPickersDay-day")(String(day))).click(),
   });

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -1,0 +1,45 @@
+import { HTML } from "bigtest";
+import { isHTMLElement } from "../test/helpers";
+
+function getHeaderElement(element: HTMLElement) {
+  const header = element.parentElement?.querySelector(".MuiPickersCalendarHeader-transitionContainer");
+  return isHTMLElement(header) ? header : null;
+}
+
+function getWeekDaysElement(element: HTMLElement) {
+  const daysHeader = element.parentElement?.querySelector(".MuiPickersCalendarHeader-daysHeader");
+  return isHTMLElement(daysHeader) ? daysHeader : null;
+}
+
+function getSelectedElement(element: HTMLElement) {
+  const dayButton = element.querySelector(".MuiPickersDay-daySelected");
+  return isHTMLElement(dayButton) ? dayButton : null;
+}
+export const Calendar = HTML.extend("MUI Calendar")
+  .selector(".MuiPickersCalendar-transitionContainer")
+  .locator((element) => {
+    const header = getHeaderElement(element)?.innerText;
+    const selectedDay = getSelectedElement(element)?.innerText;
+    return [selectedDay, header].filter(Boolean).join(" ");
+  })
+  .filters({
+    header: (element) => getHeaderElement(element)?.innerText,
+    selectedDay: (element) => {
+      const text = getSelectedElement(element)?.innerText;
+      const day = text ? parseInt(text) : NaN;
+      return Number.isNaN(day) ? undefined : day;
+    },
+    weekDay: (element) => {
+      const rootDayElement = getSelectedElement(element)?.parentElement;
+      const weekIndex = rootDayElement
+        ? Array.from(rootDayElement?.parentElement?.children ?? []).indexOf(rootDayElement)
+        : -1;
+      const weekDayElement = weekIndex != -1 ? getWeekDaysElement(element)?.children.item(weekIndex) : null;
+      return isHTMLElement(weekDayElement) ? weekDayElement.innerText : undefined;
+    },
+  })
+  .actions({
+    // TODO nextMonth
+    // TODO prevMonth
+    // TODO selectDay
+  });

--- a/src/checkbox.ts
+++ b/src/checkbox.ts
@@ -1,6 +1,6 @@
-import { CheckBox } from "@bigtest/interactor";
+import { CheckBox as BaseCheckbox } from "@bigtest/interactor";
 
-export const MaterialCheckbox = CheckBox.extend("MUI Checkbox")
+export const Checkbox = BaseCheckbox.extend("MUI Checkbox")
   .filters({
     /**
      * Checkbox component does not set the native input element to indeterminate due to inconsistent behavior across browsers.

--- a/src/datefield.ts
+++ b/src/datefield.ts
@@ -1,0 +1,16 @@
+import { TextField } from "bigtest";
+import { dispatchChange, setValue } from "./helpers";
+
+export const DateField = TextField.extend<HTMLInputElement>("date field")
+  .selector('input[type="date"]')
+  .filters({
+    date: (element) => element.valueAsDate,
+    timestamp: (element) => element.valueAsNumber,
+  })
+  .actions({
+    fillIn: ({ perform }, value: string | Date) =>
+      perform((element) => {
+        setValue(element, typeof value == "string" ? value : value.toISOString().replace(/T.*$/, ""));
+        dispatchChange(element);
+      }),
+  });

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -146,3 +146,5 @@ export const DatePicker = TextField.extend<HTMLInputElement>("MUI DatePicker")
 // export const StaticDatePicker = createInteractor<HTMLElement>("MUI StaticDatePicker").selector(
 //   ".MuiPickersStaticWrapper-staticWrapperRoot"
 // );
+
+export const NativeDatePicker = TextField.extend<HTMLInputElement>("MUI NativeDatePicker");

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -1,0 +1,148 @@
+import { bigtestGlobals } from "@bigtest/globals";
+import { createInteractor, TextField } from "bigtest";
+import { isHTMLElement } from "../test/helpers";
+import { Calendar, getDay } from "./calendar";
+
+const pickerSelector = [
+  '.MuiPopover-root[role="presentation"] .MuiPickersBasePicker-container',
+  '.MuiDialog-root[role="dialog"] .MuiPickersModal-dialogRoot',
+].join(", ");
+
+function getRootElement(element: HTMLElement) {
+  const root = element.parentElement?.parentElement;
+  return root?.classList.contains("MuiFormControl-root") ? root : null;
+}
+
+function openCalendar(element: HTMLElement) {
+  const button = element.parentElement?.querySelector(".MuiButtonBase-root") ?? element.parentElement;
+  if (isHTMLElement(button)) button.click();
+}
+
+function getCurrentDay() {
+  return new Promise<number | undefined>(
+    async (resolve) =>
+      await Picker()
+        .find(Calendar())
+        .perform((element) => resolve(getDay(element)))
+  );
+}
+
+function getDialogActionButtons(element: HTMLElement) {
+  const buttons = element.querySelectorAll(".MuiDialogActions-root > button");
+  return buttons
+    ? (Array.from(buttons).filter((button) => isHTMLElement(button, "Button")) as HTMLButtonElement[])
+    : [];
+}
+
+function getLastPicker() {
+  return Array.from(bigtestGlobals.document.querySelectorAll(pickerSelector)).slice(-1)[0];
+}
+
+const Picker = createInteractor<HTMLElement>("MUI Picker")
+  .selector(pickerSelector)
+  .filters({
+    last: { apply: (element) => element == getLastPicker(), default: true },
+  })
+  .actions({
+    clear: ({ perform }, clearLabel = "Clear") =>
+      perform((element) =>
+        getDialogActionButtons(element)
+          .find((button) => button.innerText.toLowerCase() == clearLabel.toLowerCase())
+          ?.click()
+      ),
+    today: ({ perform }, todayLabel = "Today") =>
+      perform((element) =>
+        getDialogActionButtons(element)
+          .find((button) => button.innerText.toLowerCase() == todayLabel.toLowerCase())
+          ?.click()
+      ),
+    cancel: ({ perform }) => perform((element) => getDialogActionButtons(element).slice(-2)[0]?.click()),
+    ok: ({ perform }) => perform((element) => getDialogActionButtons(element).slice(-1)[0]?.click()),
+  });
+
+const PickerToolbar = createInteractor<HTMLElement>("MUI PickerToolbar").selector(".MuiPickersToolbar-toolbar");
+
+const YearView = createInteractor<HTMLElement>("MUI YearView")
+  .selector(".MuiPickersYearSelection-container")
+  .actions({
+    select: ({ perform }, year: number) =>
+      perform((element) =>
+        (Array.from(element.children).find((child) => isHTMLElement(child) && child.innerText == String(year)) as
+          | HTMLElement
+          | undefined)?.click()
+      ),
+  });
+
+// TODO Only work with utils
+const MonthView = createInteractor<HTMLElement>("MUI MonthView").selector(".MuiPickersMonthSelection-container");
+
+// TODO export const getDatePicker = (utils: ReturnType<typeof useUtils>) =>
+
+// TODO createInteractor?
+// TODO Keyabord extends from it
+export const DatePicker = TextField.extend<HTMLInputElement>("MUI DatePicker")
+  .selector(".MuiFormControl-root[format] input[readonly], .MuiFormControl-root:not([format]) input:not([readonly])")
+  .filters({
+    valid: (element) => !element.labels?.[0].classList.contains("Mui-error"),
+    readOnly: (element) => getRootElement(element)?.hasAttribute("readonly") == true,
+    format: (element) => getRootElement(element)?.getAttribute("format"),
+  })
+  .actions({
+    setYear: async (interactor, year: number) => {
+      await interactor.perform(openCalendar);
+      try {
+        await Picker()
+          .find(PickerToolbar())
+          .perform((element) => element.querySelector("button")?.click());
+        await Picker().find(YearView()).select(year);
+      } catch (_) {
+        // NOTE Probably the toolbar is disabled
+        const currentDay = await getCurrentDay();
+        await Picker().find(Calendar()).setYear(year);
+        if (currentDay) await Picker().find(Calendar()).setDay(currentDay);
+      }
+      await Picker().ok();
+    },
+    setMonth: async (interactor, month: string) => {
+      // TODO Output error for monthview to use getDatePicker with utils
+      await interactor.perform(openCalendar);
+      const currentDay = await getCurrentDay();
+      await Picker().find(Calendar()).setMonth(month);
+      if (currentDay) await Picker().find(Calendar()).setDay(currentDay);
+      await Picker().ok();
+    },
+    setDay: async (interactor, day: number) => {
+      await interactor.perform(openCalendar);
+      await Picker().find(Calendar()).setDay(day);
+      await Picker().ok();
+    },
+    setDate: async (interactor, targetDate: { day?: number; month?: string; year?: number }) => {
+      await interactor.perform(openCalendar);
+      if (targetDate.year) await Picker().find(Calendar()).setYear(targetDate.year);
+      if (targetDate.month) await Picker().find(Calendar()).setMonth(targetDate.month);
+      if (targetDate.day) await Picker().find(Calendar()).setDay(targetDate.day);
+      await Picker().ok();
+    },
+    setToday: async (interactor, todayLabel?: string) => {
+      await interactor.perform(openCalendar);
+      await Picker().today(todayLabel);
+      await Picker().ok();
+    },
+    clear: async (interactor, clearLabel?: string) => {
+      await interactor.perform(openCalendar);
+      await Picker().clear(clearLabel);
+    },
+  });
+
+// NOTE the TextField fillIn doesn't work and doesn't trigger date change event
+// export const KeyboardDatePicker = TextField.extend<HTMLInputElement>("MUI KeyboardDatePicker")
+//   .selector(".MuiFormControl-root:not([format]) input:not([readonly])")
+//   .filters({
+//     error: (element) => {
+//       return element.labels?.[0].classList.contains("Mui-error");
+//     },
+//   });
+
+// export const StaticDatePicker = createInteractor<HTMLElement>("MUI StaticDatePicker").selector(
+//   ".MuiPickersStaticWrapper-staticWrapperRoot"
+// );

--- a/src/datepicker.ts
+++ b/src/datepicker.ts
@@ -146,5 +146,3 @@ export const DatePicker = TextField.extend<HTMLInputElement>("MUI DatePicker")
 // export const StaticDatePicker = createInteractor<HTMLElement>("MUI StaticDatePicker").selector(
 //   ".MuiPickersStaticWrapper-staticWrapperRoot"
 // );
-
-export const NativeDatePicker = TextField.extend<HTMLInputElement>("MUI NativeDatePicker");

--- a/src/datetimefield.ts
+++ b/src/datetimefield.ts
@@ -1,0 +1,13 @@
+import { TextField } from "bigtest";
+import { dispatchChange, setValue } from "./helpers";
+
+export const DateTimeField = TextField.extend<HTMLInputElement>("datetime field")
+  .selector('input[type="datetime-local"]')
+  .filters({ timestamp: (element) => element.valueAsNumber })
+  .actions({
+    fillIn: ({ perform }, value: string | Date) =>
+      perform((element) => {
+        setValue(element, typeof value == "string" ? value : value.toISOString().replace(/Z$/, ""));
+        dispatchChange(element);
+      }),
+  });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,1 @@
+export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,1 +1,18 @@
 export const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// NOTE: Copy-paste from https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/fill-in.ts
+export function setValue(element: HTMLInputElement, value: string): void {
+  let property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), "value");
+  if (property && property.set) {
+    property.set.call(element, value);
+  } else {
+    // if the value property on the element protoype is not present
+    // then there are worse problems. But this is very typesafe!
+    element.value = value;
+  }
+}
+
+export function dispatchChange(element: HTMLElement): boolean {
+  let Event = element.ownerDocument.defaultView?.Event || window.Event;
+  return element.dispatchEvent(new Event("change", { bubbles: true, cancelable: false }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,10 @@ import * as Bigtest from "@bigtest/interactor";
 export { Bigtest };
 export { HTML, including, matching, and, or, not, some, every } from "@bigtest/interactor";
 
+export * from "./datefield";
+export * from "./timefield";
+export * from "./datetimefield";
+
 export * from "./checkbox";
 export * from "./body";
 export * from "./calendar";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Button } from "@bigtest/interactor";
-export { MaterialCheckbox as CheckBox } from "./checkbox";
-export { Body } from "./body";
-export { Calendar } from "./calendar";
+export * from "./checkbox";
+export * from "./body";
+export * from "./calendar";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,5 +6,6 @@ export { HTML, including, matching, and, or, not, some, every } from "@bigtest/i
 export * from "./checkbox";
 export * from "./body";
 export * from "./calendar";
+export * from "./datepicker";
 export { default as Fab } from "./fab";
 export { Button } from "@bigtest/interactor";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-export { Button } from '@bigtest/interactor'
+export { Button } from "@bigtest/interactor";
+
+export { Calendar } from "./calendar";

--- a/src/timefield.ts
+++ b/src/timefield.ts
@@ -1,0 +1,16 @@
+import { TextField } from "bigtest";
+import { dispatchChange, setValue } from "./helpers";
+
+export const TimeField = TextField.extend<HTMLInputElement>("time field")
+  .selector('input[type="time"]')
+  .filters({
+    date: (element) => element.valueAsDate,
+    timestamp: (element) => element.valueAsNumber,
+  })
+  .actions({
+    fillIn: ({ perform }, value: string | Date) =>
+      perform((element) => {
+        setValue(element, typeof value == "string" ? value : value.toISOString().replace(/^.*T(.*)Z$/, "$1"));
+        dispatchChange(element);
+      }),
+  });

--- a/test/button.test.tsx
+++ b/test/button.test.tsx
@@ -1,11 +1,9 @@
-import { test, Page} from "bigtest";
+import { test, Page } from "bigtest";
 import { Button as btButton } from "../src/index";
 import { Button as MyButton } from "@material-ui/core";
 import { render } from "./helpers";
 
 export default test("Button")
- .step(Page.visit("/"))
- .step("rendering a button", async() => {
-   render(<MyButton>Click me</MyButton>)
- })
- .assertion(btButton("CLICK ME").exists())
+  .step(Page.visit("/"))
+  .step(render(<MyButton>Click me</MyButton>))
+  .assertion(btButton("CLICK ME").exists());

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -9,35 +9,27 @@ const CalendarWithUtils = getCalendar(new DateFnsUtils());
 
 export default test("Calendar")
   .step(Page.visit("/"))
-  .child("filter by locator", (test) =>
-    test.step("render", renderComponent()).assertion(Calendar("18 August 2014").exists())
-  )
+  .child("filter by locator", (test) => test.step(renderComponent()).assertion(Calendar("18 August 2014").exists()))
   .child("filter by title", (test) =>
-    test.step("render", renderComponent()).assertion(Calendar({ title: "August 2014" }).exists())
+    test.step(renderComponent()).assertion(Calendar({ title: "August 2014" }).exists())
   )
-  .child("filter by month", (test) =>
-    test.step("render", renderComponent()).assertion(Calendar({ month: "August" }).exists())
-  )
-  .child("filter by year", (test) =>
-    test.step("render", renderComponent()).assertion(Calendar({ year: "2014" }).exists())
-  )
-  .child("filter by day", (test) => test.step("render", renderComponent()).assertion(Calendar({ day: 18 }).exists()))
-  .child("filter by weekDay", (test) =>
-    test.step("render", renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists())
-  )
+  .child("filter by month", (test) => test.step(renderComponent()).assertion(Calendar({ month: "August" }).exists()))
+  .child("filter by year", (test) => test.step(renderComponent()).assertion(Calendar({ year: "2014" }).exists()))
+  .child("filter by day", (test) => test.step(renderComponent()).assertion(Calendar({ day: 18 }).exists()))
+  .child("filter by weekDay", (test) => test.step(renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists()))
   // TODO Don't work well on different environments
   // .child("filter by date", (test) =>
-  //   test.step("render", renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
+  //   test.step(renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
   // )
   .child("nextMonth action", (test) =>
     test
-      .step("render", renderComponent())
+      .step(renderComponent())
       .step("go to next month", () => Calendar().nextMonth())
       .assertion(Calendar().has({ title: "September 2014" }))
   )
   .child("prevMonth action", (test) =>
     test
-      .step("render", renderComponent())
+      .step(renderComponent())
       .step("go to prev month", () => Calendar().prevMonth())
       .assertion(Calendar().has({ title: "July 2014" }))
   )
@@ -45,13 +37,13 @@ export default test("Calendar")
     test
       .child("in future", (test) =>
         test
-          .step("render", renderComponent())
+          .step(renderComponent())
           .step("go to 2015", () => Calendar().setYear(2015))
           .assertion(Calendar().has({ title: "August 2015" }))
       )
       .child("in past", (test) =>
         test
-          .step("render", renderComponent())
+          .step(renderComponent())
           .step("go to 2013", () => Calendar().setYear(2013))
           .assertion(Calendar().has({ title: "August 2013" }))
       )
@@ -60,13 +52,13 @@ export default test("Calendar")
     test
       .child("in future", (test) =>
         test
-          .step("render", renderComponent())
+          .step(renderComponent())
           .step("go to September", () => Calendar().setMonth("September"))
           .assertion(Calendar().has({ title: "September 2014" }))
       )
       .child("in past", (test) =>
         test
-          .step("render", renderComponent())
+          .step(renderComponent())
           .step("go to July", () => Calendar().setMonth("July"))
           .assertion(Calendar().has({ title: "July 2014" }))
       )
@@ -75,20 +67,20 @@ export default test("Calendar")
     test
       .child("in future", (test) =>
         test
-          .step("render", renderComponent())
+          .step(renderComponent())
           .step("go to September", () => CalendarWithUtils().setMonth("September"))
           .assertion(Calendar().has({ title: "September 2014" }))
       )
       .child("in past", (test) =>
         test
-          .step("render", renderComponent())
+          .step(renderComponent())
           .step("go to July", () => CalendarWithUtils().setMonth("July"))
           .assertion(Calendar().has({ title: "July 2014" }))
       )
   )
   .child("setDay action", (test) =>
     test
-      .step("render", renderComponent())
+      .step(renderComponent())
       .step("select the 15th day", () => Calendar().setDay(15))
       .assertion(Calendar("15 August 2014").exists())
   )
@@ -98,21 +90,20 @@ export default test("Calendar")
   // TODO Props to test `disableFuture`, `disablePast`, `maxDate`, `minDate`
   // .child("nextMonth action with disableFuture", (test) =>
   //   test
-  //     .step("render", renderComponent({ date: new Date(), disableFuture: true }))
+  //     .step(renderComponent({ date: new Date(), disableFuture: true }))
   //     .step("try go to next month", () => Calendar().nextMonth())
   //     .assertion(Calendar().has({ title: "???" }))
   // )
   // TODO Test exception message?
   // .child("setDay action on disabled day", (test) =>
   //   test
-  //     .step("render", renderComponent({ maxDate: new Date("2014-08-18") }))
+  //     .step(renderComponent({ maxDate: new Date("2014-08-18") }))
   //     .step("select the 20th day", () => Calendar().setDay(20))
   //     .assertion(Calendar("18 August 2014").exists())
   // )
   .child("setDay action with fully custom day render", (test) =>
     test
       .step(
-        "render",
         renderComponent({
           renderDay: (day, _selectedDate, dayInCurrentMonth, _dayComponent) => (
             <button hidden={!dayInCurrentMonth}>{day?.getDate()}</button>
@@ -129,7 +120,6 @@ export default test("Calendar")
   //   "setDay action with 'semi-transparent' days",
   //   (test) =>
   //     test.step(
-  //       "render",
   //       // NOTE: Another `cool` thing we can render days from prev/next months and they are clickable
   //       renderComponent((onChange) => ({
   //         renderDay: (day, _selectedDate, dayInCurrentMonth, dayComponent) =>
@@ -146,13 +136,13 @@ export default test("Calendar")
   // )
   .child("nextMonth action with custom icon", (test) =>
     test
-      .step("render", renderComponent({ rightArrowIcon: <span /> }))
+      .step(renderComponent({ rightArrowIcon: <span /> }))
       .step("go to next month", () => Calendar().nextMonth())
       .assertion(Calendar().has({ title: "September 2014" }))
   )
   .child("prevMonth action with custom icon", (test) =>
     test
-      .step("render", renderComponent({ leftArrowIcon: <span /> }))
+      .step(renderComponent({ leftArrowIcon: <span /> }))
       .step("go to prev month", () => Calendar().prevMonth())
       .assertion(Calendar().has({ title: "July 2014" }))
   );

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -25,9 +25,10 @@ export default test("Calendar")
   .child("filter by weekDay", (test) =>
     test.step("render", renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists())
   )
-  .child("filter by date", (test) =>
-    test.step("render", renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
-  )
+  // TODO Don't work well on different environments
+  // .child("filter by date", (test) =>
+  //   test.step("render", renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
+  // )
   .child("nextMonth action", (test) =>
     test
       .step("render", renderComponent())

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -25,15 +25,9 @@ export default test("Calendar")
   .child("filter by weekDay", (test) =>
     test.step("render", renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists())
   )
-  // NOTE: Doesn't work
-  // │ ERROR did not find MUI Calendar with date "2014-08-18T00:00:00.000Z", did you mean one of:
-  // │
-  // │ ┃ date: "2014-08-18T00:00:00.000Z" ┃
-  // │ ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
-  // │ ┃ ⨯ "2014-08-18T22:00:00.000Z"     ┃
-  // .child("filter by date", (test) =>
-  //   test.step("render", renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
-  // )
+  .child("filter by date", (test) =>
+    test.step("render", renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
+  )
   .child("nextMonth action", (test) =>
     test
       .step("render", renderComponent())

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -1,53 +1,52 @@
 import "date-fns";
+import { createElement, useState } from "react";
 import { test, Page } from "bigtest";
 import { Calendar as Component, MuiPickersUtilsProvider } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 import { Calendar } from "../src";
 import { render } from "./helpers";
 
+const renderComponent = () =>
+  render(
+    createElement(() => {
+      const [selectedDate, setSelectedDate] = useState<Date | null>(new Date("2014-08-18T21:11:54"));
+      return (
+        <MuiPickersUtilsProvider utils={DateFnsUtils}>
+          <Component onChange={setSelectedDate} date={selectedDate} />
+        </MuiPickersUtilsProvider>
+      );
+    })
+  );
+
 export default test("Calendar")
   .step(Page.visit("/"))
-  .child("test `filter` by locator", (test) =>
-    test
-      .step("render", () =>
-        render(
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
-          </MuiPickersUtilsProvider>
-        )
-      )
-      .assertion(Calendar("18 August 2014").exists())
+  .child("filter by locator", (test) =>
+    test.step("render", renderComponent).assertion(Calendar("18 August 2014").exists())
   )
-  .child("test `filter` by header", (test) =>
-    test
-      .step("render", () =>
-        render(
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
-          </MuiPickersUtilsProvider>
-        )
-      )
-      .assertion(Calendar({ header: "August 2014" }).exists())
+  .child("filter by title", (test) =>
+    test.step("render", renderComponent).assertion(Calendar({ title: "August 2014" }).exists())
   )
-  .child("test `filter` by selectedDay", (test) =>
-    test
-      .step("render", () =>
-        render(
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
-          </MuiPickersUtilsProvider>
-        )
-      )
-      .assertion(Calendar({ selectedDay: 18 }).exists())
+  .child("filter by selectedDay", (test) =>
+    test.step("render", renderComponent).assertion(Calendar({ selectedDay: 18 }).exists())
   )
-  .child("test `filter` by weekDay", (test) =>
+  .child("filter by weekDay", (test) =>
+    test.step("render", renderComponent).assertion(Calendar({ weekDay: "Mo" }).exists())
+  )
+  .child("nextMonth action", (test) =>
     test
-      .step("render", () =>
-        render(
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
-          </MuiPickersUtilsProvider>
-        )
-      )
-      .assertion(Calendar({ weekDay: "Mo" }).exists())
+      .step("render", renderComponent)
+      .step("nextMonth", () => Calendar().nextMonth())
+      .assertion(Calendar().has({ title: "September 2014" }))
+  )
+  .child("`prevMonth` action", (test) =>
+    test
+      .step("render", renderComponent)
+      .step("prevMonth", () => Calendar().prevMonth())
+      .assertion(Calendar().has({ title: "July 2014" }))
+  )
+  .child("`selectDay` action", (test) =>
+    test
+      .step("render", renderComponent)
+      .step("selectDay", () => Calendar().selectDay(15))
+      .assertion(Calendar("15 August 2014").exists())
   );

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -1,18 +1,27 @@
 import "date-fns";
-import { createElement, useState } from "react";
+import { cloneElement, ComponentProps, createElement, PropsWithChildren, useState } from "react";
 import { test, Page } from "bigtest";
 import { Calendar as Component, MuiPickersUtilsProvider } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 import { Calendar } from "../src";
 import { render } from "./helpers";
 
-const renderComponent = () =>
+const renderComponent = (
+  getProps?:
+    | Partial<ComponentProps<typeof Component>>
+    | ((onChange?: (date: Date) => void) => Partial<ComponentProps<typeof Component>>)
+) => () =>
   render(
     createElement(() => {
-      const [selectedDate, setSelectedDate] = useState<Date | null>(new Date("2014-08-18T21:11:54"));
+      const props = typeof getProps == "function" ? getProps() : getProps;
+      const [selectedDate, setSelectedDate] = useState<Date | null>(props?.date ?? new Date("2014-08-18"));
       return (
         <MuiPickersUtilsProvider utils={DateFnsUtils}>
-          <Component onChange={setSelectedDate} date={selectedDate} />
+          <Component
+            onChange={setSelectedDate}
+            date={selectedDate}
+            {...(typeof getProps == "function" ? getProps(setSelectedDate) : getProps)}
+          />
         </MuiPickersUtilsProvider>
       );
     })
@@ -21,32 +30,96 @@ const renderComponent = () =>
 export default test("Calendar")
   .step(Page.visit("/"))
   .child("filter by locator", (test) =>
-    test.step("render", renderComponent).assertion(Calendar("18 August 2014").exists())
+    test.step("render", renderComponent()).assertion(Calendar("18 August 2014").exists())
   )
   .child("filter by title", (test) =>
-    test.step("render", renderComponent).assertion(Calendar({ title: "August 2014" }).exists())
+    test.step("render", renderComponent()).assertion(Calendar({ title: "August 2014" }).exists())
   )
   .child("filter by selectedDay", (test) =>
-    test.step("render", renderComponent).assertion(Calendar({ selectedDay: 18 }).exists())
+    test.step("render", renderComponent()).assertion(Calendar({ selectedDay: 18 }).exists())
   )
   .child("filter by weekDay", (test) =>
-    test.step("render", renderComponent).assertion(Calendar({ weekDay: "Mo" }).exists())
+    test.step("render", renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists())
   )
   .child("nextMonth action", (test) =>
     test
-      .step("render", renderComponent)
-      .step("nextMonth", () => Calendar().nextMonth())
+      .step("render", renderComponent())
+      .step("go to next month", () => Calendar().nextMonth())
       .assertion(Calendar().has({ title: "September 2014" }))
   )
-  .child("`prevMonth` action", (test) =>
+  .child("prevMonth action", (test) =>
     test
-      .step("render", renderComponent)
-      .step("prevMonth", () => Calendar().prevMonth())
+      .step("render", renderComponent())
+      .step("go to prev month", () => Calendar().prevMonth())
       .assertion(Calendar().has({ title: "July 2014" }))
   )
-  .child("`selectDay` action", (test) =>
+  .child("selectDay action", (test) =>
     test
-      .step("render", renderComponent)
-      .step("selectDay", () => Calendar().selectDay(15))
+      .step("render", renderComponent())
+      .step("select the 15th day", () => Calendar().selectDay(15))
       .assertion(Calendar("15 August 2014").exists())
+  )
+  // TODO What should do if user want to click on the disabled `nextMonth` button? Raise exception? Do nothing?
+  // TODO How to test an exception with BigTest?
+  // TODO The same for `prevMonth` and `selectDay` and `shouldDisableDate`
+  // TODO Props to test `disableFuture`, `disablePast`, `maxDate`, `minDate`
+  // .child("nextMonth action with disableFuture", (test) =>
+  //   test
+  //     .step("render", renderComponent({ date: new Date(), disableFuture: true }))
+  //     .step("try go to next month", () => Calendar().nextMonth())
+  //     .assertion(Calendar().has({ title: "???" }))
+  // )
+  .child("selectDay action on disabled day", (test) =>
+    test
+      .step("render", renderComponent({ maxDate: new Date("2014-08-18") }))
+      .step("select the 20th day", () => Calendar().selectDay(20))
+      // TODO Test exception message?
+      .assertion(Calendar("18 August 2014").exists())
+  )
+  .child("selectDay action with fully custom day render", (test) =>
+    test
+      .step(
+        "render",
+        renderComponent({
+          renderDay: (day, _selectedDate, dayInCurrentMonth, _dayComponent) => (
+            <button hidden={!dayInCurrentMonth}>{day?.getDate()}</button>
+          ),
+        })
+      )
+      .step("select the 20th day", () => Calendar().selectDay(20))
+      // NOTE There is no way to filter by selected day with a fully custom day render
+      // But we still be able do day clicks, just can't test it ¯\_(ツ)_/¯
+      .assertion(Calendar("August 2014").exists())
+  )
+  .child(
+    "selectDay action with 'semi-transparent' days",
+    (test) =>
+      test.step(
+        "render",
+        // NOTE: Another `cool` thing we can render days from prev/next months and they are clickable
+        renderComponent((onChange) => ({
+          renderDay: (day, _selectedDate, dayInCurrentMonth, dayComponent) =>
+            cloneElement(dayComponent, {
+              hidden: false,
+              ...(dayInCurrentMonth
+                ? undefined
+                : { style: { opacity: "0.5" }, onClick: () => onChange?.(day as Date) }),
+            }),
+        }))
+      )
+    // TODO But 4th day appears twice :(
+    // .step("select the 4th day", () => Calendar().selectDay(4))
+    // .assertion(Calendar("4 September 2014").exists())
+  )
+  .child("nextMonth action with custom icon", (test) =>
+    test
+      .step("render", renderComponent({ rightArrowIcon: <span /> }))
+      .step("go to next month", () => Calendar().nextMonth())
+      .assertion(Calendar().has({ title: "September 2014" }))
+  )
+  .child("prevMonth action with custom icon", (test) =>
+    test
+      .step("render", renderComponent({ leftArrowIcon: <span /> }))
+      .step("go to prev month", () => Calendar().prevMonth())
+      .assertion(Calendar().has({ title: "July 2014" }))
   );

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -71,12 +71,6 @@ export default test("Calendar")
       .step("select the 15th day", () => Calendar().setDay(15))
       .assertion(Calendar("15 August 2014").exists())
   )
-  .child("setDate action", (test) =>
-    test
-      .step("render", renderComponent())
-      .step("set date 23 May 2016", () => Calendar().setDate({ day: 23, month: "May", year: 2016 }))
-      .assertion(Calendar("23 May 2016").exists())
-  )
   // TODO What should do if user want to click on the disabled `nextMonth` button? Raise exception? Do nothing?
   // TODO How to test an exception with BigTest?
   // TODO The same for `prevMonth` and `setDay` and `shouldDisableDate`

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -1,4 +1,3 @@
-import { cloneElement } from "react";
 import { test, Page } from "bigtest";
 import { Calendar as Component } from "@material-ui/pickers";
 import { Calendar } from "../src";
@@ -36,46 +35,47 @@ export default test("Calendar")
       .step("go to prev month", () => Calendar().prevMonth())
       .assertion(Calendar().has({ title: "July 2014" }))
   )
-  // TODO Add tests with min/max date
-  // TODO Don't work
-  // │ Unknown error occurred: This is likely a bug in BigTest and should be reported at https://github.com/thefrontside/bigtest/issues.
-  // .child("setMonth action", (test) =>
-  //   test
-  //     .child("in future", (test) =>
-  //       test
-  //         .step("render", renderComponent())
-  //         .step("go to September", () => Calendar().setMonth("September"))
-  //         .assertion(Calendar().has({ title: "September 2015" }))
-  //     )
-  //     .child("in past", (test) =>
-  //       test
-  //         .step("render", renderComponent())
-  //         .step("go to July", () => Calendar().setMonth("July"))
-  //         .assertion(Calendar().has({ title: "July 2013" }))
-  //     )
-  // )
-  // TODO Don't work
-  // │ Unknown error occurred: This is likely a bug in BigTest and should be reported at https://github.com/thefrontside/bigtest/issues.
-  // .child("setYear action", (test) =>
-  //   test
-  //     .child("in future", (test) =>
-  //       test
-  //         .step("render", renderComponent())
-  //         .step("go to 2015", () => Calendar().setYear(2015))
-  //         .assertion(Calendar().has({ title: "August 2015" }))
-  //     )
-  //     .child("in past", (test) =>
-  //       test
-  //         .step("render", renderComponent())
-  //         .step("go to 2013", () => Calendar().setYear(2013))
-  //         .assertion(Calendar().has({ title: "August 2013" }))
-  //     )
-  // )
+  .child("setYear action", (test) =>
+    test
+      .child("in future", (test) =>
+        test
+          .step("render", renderComponent())
+          .step("go to 2015", () => Calendar().setYear(2015))
+          .assertion(Calendar().has({ title: "August 2015" }))
+      )
+      .child("in past", (test) =>
+        test
+          .step("render", renderComponent())
+          .step("go to 2013", () => Calendar().setYear(2013))
+          .assertion(Calendar().has({ title: "August 2013" }))
+      )
+  )
+  .child("setMonth action", (test) =>
+    test
+      .child("in future", (test) =>
+        test
+          .step("render", renderComponent())
+          .step("go to September", () => Calendar().setMonth("September"))
+          .assertion(Calendar().has({ title: "September 2014" }))
+      )
+      .child("in past", (test) =>
+        test
+          .step("render", renderComponent())
+          .step("go to July", () => Calendar().setMonth("July"))
+          .assertion(Calendar().has({ title: "July 2014" }))
+      )
+  )
   .child("setDay action", (test) =>
     test
       .step("render", renderComponent())
       .step("select the 15th day", () => Calendar().setDay(15))
       .assertion(Calendar("15 August 2014").exists())
+  )
+  .child("setDate action", (test) =>
+    test
+      .step("render", renderComponent())
+      .step("set date 23 May 2016", () => Calendar().setDate({ day: 23, month: "May", year: 2016 }))
+      .assertion(Calendar("23 May 2016").exists())
   )
   // TODO What should do if user want to click on the disabled `nextMonth` button? Raise exception? Do nothing?
   // TODO How to test an exception with BigTest?
@@ -87,13 +87,13 @@ export default test("Calendar")
   //     .step("try go to next month", () => Calendar().nextMonth())
   //     .assertion(Calendar().has({ title: "???" }))
   // )
-  .child("setDay action on disabled day", (test) =>
-    test
-      .step("render", renderComponent({ maxDate: new Date("2014-08-18") }))
-      .step("select the 20th day", () => Calendar().setDay(20))
-      // TODO Test exception message?
-      .assertion(Calendar("18 August 2014").exists())
-  )
+  // TODO Test exception message?
+  // .child("setDay action on disabled day", (test) =>
+  //   test
+  //     .step("render", renderComponent({ maxDate: new Date("2014-08-18") }))
+  //     .step("select the 20th day", () => Calendar().setDay(20))
+  //     .assertion(Calendar("18 August 2014").exists())
+  // )
   .child("setDay action with fully custom day render", (test) =>
     test
       .step(
@@ -109,26 +109,26 @@ export default test("Calendar")
       // But we still be able do day clicks, just can't test it ¯\_(ツ)_/¯
       .assertion(Calendar("August 2014").exists())
   )
-  .child(
-    "setDay action with 'semi-transparent' days",
-    (test) =>
-      test.step(
-        "render",
-        // NOTE: Another `cool` thing we can render days from prev/next months and they are clickable
-        renderComponent((onChange) => ({
-          renderDay: (day, _selectedDate, dayInCurrentMonth, dayComponent) =>
-            cloneElement(dayComponent, {
-              hidden: false,
-              ...(dayInCurrentMonth
-                ? undefined
-                : { style: { opacity: "0.5" }, onClick: () => onChange?.(day as Date) }),
-            }),
-        }))
-      )
-    // TODO But 4th day appears twice :(
-    // .step("select the 4th day", () => Calendar().setDay(4))
-    // .assertion(Calendar("4 September 2014").exists())
-  )
+  // TODO But 4th day appears twice :(
+  // .child(
+  //   "setDay action with 'semi-transparent' days",
+  //   (test) =>
+  //     test.step(
+  //       "render",
+  //       // NOTE: Another `cool` thing we can render days from prev/next months and they are clickable
+  //       renderComponent((onChange) => ({
+  //         renderDay: (day, _selectedDate, dayInCurrentMonth, dayComponent) =>
+  //           cloneElement(dayComponent, {
+  //             hidden: false,
+  //             ...(dayInCurrentMonth
+  //               ? undefined
+  //               : { style: { opacity: "0.5" }, onClick: () => onChange?.(day as Date) }),
+  //           }),
+  //       }))
+  //     )
+  //   // .step("select the 4th day", () => Calendar().setDay(4))
+  //   // .assertion(Calendar("4 September 2014").exists())
+  // )
   .child("nextMonth action with custom icon", (test) =>
     test
       .step("render", renderComponent({ rightArrowIcon: <span /> }))

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -9,14 +9,16 @@ const CalendarWithUtils = getCalendar(new DateFnsUtils());
 
 export default test("Calendar")
   .step(Page.visit("/"))
-  .child("filter by locator", (test) => test.step(renderComponent()).assertion(Calendar("18 August 2014").exists()))
-  .child("filter by title", (test) =>
-    test.step(renderComponent()).assertion(Calendar({ title: "August 2014" }).exists())
+  .child("filters", (test) =>
+    test
+      .step(renderComponent())
+      .assertion(Calendar("18 August 2014").exists())
+      .assertion(Calendar({ title: "August 2014" }).exists())
+      .assertion(Calendar({ month: "August" }).exists())
+      .assertion(Calendar({ year: "2014" }).exists())
+      .assertion(Calendar({ day: 18 }).exists())
+      .assertion(Calendar({ weekDay: "Mo" }).exists())
   )
-  .child("filter by month", (test) => test.step(renderComponent()).assertion(Calendar({ month: "August" }).exists()))
-  .child("filter by year", (test) => test.step(renderComponent()).assertion(Calendar({ year: "2014" }).exists()))
-  .child("filter by day", (test) => test.step(renderComponent()).assertion(Calendar({ day: 18 }).exists()))
-  .child("filter by weekDay", (test) => test.step(renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists()))
   // TODO Don't work well on different environments
   // .child("filter by date", (test) =>
   //   test.step(renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -1,31 +1,10 @@
-import "date-fns";
-import { cloneElement, ComponentProps, createElement, PropsWithChildren, useState } from "react";
+import { cloneElement } from "react";
 import { test, Page } from "bigtest";
-import { Calendar as Component, MuiPickersUtilsProvider } from "@material-ui/pickers";
-import DateFnsUtils from "@date-io/date-fns";
+import { Calendar as Component } from "@material-ui/pickers";
 import { Calendar } from "../src";
-import { render } from "./helpers";
+import { getPickerRenderer } from "./helpers";
 
-const renderComponent = (
-  getProps?:
-    | Partial<ComponentProps<typeof Component>>
-    | ((onChange?: (date: Date) => void) => Partial<ComponentProps<typeof Component>>)
-) => () =>
-  render(
-    createElement(() => {
-      const props = typeof getProps == "function" ? getProps() : getProps;
-      const [selectedDate, setSelectedDate] = useState<Date | null>(props?.date ?? new Date("2014-08-18"));
-      return (
-        <MuiPickersUtilsProvider utils={DateFnsUtils}>
-          <Component
-            onChange={setSelectedDate}
-            date={selectedDate}
-            {...(typeof getProps == "function" ? getProps(setSelectedDate) : getProps)}
-          />
-        </MuiPickersUtilsProvider>
-      );
-    })
-  );
+const renderComponent = getPickerRenderer(Component);
 
 export default test("Calendar")
   .step(Page.visit("/"))
@@ -34,6 +13,12 @@ export default test("Calendar")
   )
   .child("filter by title", (test) =>
     test.step("render", renderComponent()).assertion(Calendar({ title: "August 2014" }).exists())
+  )
+  .child("filter by month", (test) =>
+    test.step("render", renderComponent()).assertion(Calendar({ month: "August" }).exists())
+  )
+  .child("filter by year", (test) =>
+    test.step("render", renderComponent()).assertion(Calendar({ year: "2014" }).exists())
   )
   .child("filter by selectedDay", (test) =>
     test.step("render", renderComponent()).assertion(Calendar({ selectedDay: 18 }).exists())
@@ -53,6 +38,41 @@ export default test("Calendar")
       .step("go to prev month", () => Calendar().prevMonth())
       .assertion(Calendar().has({ title: "July 2014" }))
   )
+  // TODO Add tests with min/max date
+  // TODO Don't work
+  // │ Unknown error occurred: This is likely a bug in BigTest and should be reported at https://github.com/thefrontside/bigtest/issues.
+  // .child("setMonth action", (test) =>
+  //   test
+  //     .child("in future", (test) =>
+  //       test
+  //         .step("render", renderComponent())
+  //         .step("go to September", () => Calendar().setMonth("September"))
+  //         .assertion(Calendar().has({ title: "September 2015" }))
+  //     )
+  //     .child("in past", (test) =>
+  //       test
+  //         .step("render", renderComponent())
+  //         .step("go to July", () => Calendar().setMonth("July"))
+  //         .assertion(Calendar().has({ title: "July 2013" }))
+  //     )
+  // )
+  // TODO Don't work
+  // │ Unknown error occurred: This is likely a bug in BigTest and should be reported at https://github.com/thefrontside/bigtest/issues.
+  // .child("setYear action", (test) =>
+  //   test
+  //     .child("in future", (test) =>
+  //       test
+  //         .step("render", renderComponent())
+  //         .step("go to 2015", () => Calendar().setYear(2015))
+  //         .assertion(Calendar().has({ title: "August 2015" }))
+  //     )
+  //     .child("in past", (test) =>
+  //       test
+  //         .step("render", renderComponent())
+  //         .step("go to 2013", () => Calendar().setYear(2013))
+  //         .assertion(Calendar().has({ title: "August 2013" }))
+  //     )
+  // )
   .child("selectDay action", (test) =>
     test
       .step("render", renderComponent())
@@ -123,3 +143,6 @@ export default test("Calendar")
       .step("go to prev month", () => Calendar().prevMonth())
       .assertion(Calendar().has({ title: "July 2014" }))
   );
+
+// TODO SetMonth, try to go next/prev month until wanted month, check year. If we went in wrong direction, go back
+// TODO SetYear because we know current year

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -1,0 +1,53 @@
+import "date-fns";
+import { test, Page } from "bigtest";
+import { Calendar as Component, MuiPickersUtilsProvider } from "@material-ui/pickers";
+import DateFnsUtils from "@date-io/date-fns";
+import { Calendar } from "../src";
+import { render } from "./helpers";
+
+export default test("Calendar")
+  .step(Page.visit("/"))
+  .child("test `filter` by locator", (test) =>
+    test
+      .step("render", () =>
+        render(
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
+          </MuiPickersUtilsProvider>
+        )
+      )
+      .assertion(Calendar("18 August 2014").exists())
+  )
+  .child("test `filter` by header", (test) =>
+    test
+      .step("render", () =>
+        render(
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
+          </MuiPickersUtilsProvider>
+        )
+      )
+      .assertion(Calendar({ header: "August 2014" }).exists())
+  )
+  .child("test `filter` by selectedDay", (test) =>
+    test
+      .step("render", () =>
+        render(
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
+          </MuiPickersUtilsProvider>
+        )
+      )
+      .assertion(Calendar({ selectedDay: 18 }).exists())
+  )
+  .child("test `filter` by weekDay", (test) =>
+    test
+      .step("render", () =>
+        render(
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            <Component onChange={() => {}} date={new Date("2014-08-18T21:11:54")} />
+          </MuiPickersUtilsProvider>
+        )
+      )
+      .assertion(Calendar({ weekDay: "Mo" }).exists())
+  );

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -22,39 +22,31 @@ export default test("Calendar")
       // TODO Don't work well on different environments
       // .assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
       .child("nextMonth action", (test) =>
-        test.step("go to next month", () => calendar.nextMonth()).assertion(Calendar().has({ title: "September 2014" }))
+        test.step(calendar.nextMonth()).assertion(Calendar().has({ title: "September 2014" }))
       )
       .child("prevMonth action", (test) =>
-        test.step("go to prev month", () => calendar.prevMonth()).assertion(Calendar().has({ title: "July 2014" }))
+        test.step(calendar.prevMonth()).assertion(Calendar().has({ title: "July 2014" }))
       )
       // NOTE: Using here `Calendar("18 August 2014")` leads to issue where the second nextMonth step throws NoSuchElementError
       .child("setYear action in future", (test) =>
-        test.step("go to 2015", () => Calendar().setYear(2015)).assertion(Calendar().has({ title: "August 2015" }))
+        test.step(Calendar().setYear(2015)).assertion(Calendar().has({ title: "August 2015" }))
       )
       .child("setYear action in past", (test) =>
-        test.step("go to 2013", () => Calendar().setYear(2013)).assertion(Calendar().has({ title: "August 2013" }))
+        test.step(Calendar().setYear(2013)).assertion(Calendar().has({ title: "August 2013" }))
       )
       .child("setMonth action in future", (test) =>
-        test
-          .step("go to September", () => Calendar().setMonth("September"))
-          .assertion(Calendar().has({ title: "September 2014" }))
+        test.step(Calendar().setMonth("September")).assertion(Calendar().has({ title: "September 2014" }))
       )
       .child("setMonth action in past", (test) =>
-        test.step("go to July", () => Calendar().setMonth("July")).assertion(Calendar().has({ title: "July 2014" }))
+        test.step(Calendar().setMonth("July")).assertion(Calendar().has({ title: "July 2014" }))
       )
       .child("setMonth action with utils in future", (test) =>
-        test
-          .step("go to September", () => CalendarWithUtils().setMonth("September"))
-          .assertion(Calendar().has({ title: "September 2014" }))
+        test.step(CalendarWithUtils().setMonth("September")).assertion(Calendar().has({ title: "September 2014" }))
       )
       .child("setMonth action with utils in past", (test) =>
-        test
-          .step("go to July", () => CalendarWithUtils().setMonth("July"))
-          .assertion(Calendar().has({ title: "July 2014" }))
+        test.step(CalendarWithUtils().setMonth("July")).assertion(Calendar().has({ title: "July 2014" }))
       )
-      .child("setDay action", (test) =>
-        test.step("select the 15th day", () => calendar.setDay(15)).assertion(Calendar("15 August 2014").exists())
-      )
+      .child("setDay action", (test) => test.step(calendar.setDay(15)).assertion(Calendar("15 August 2014").exists()))
   )
   .child("custom renders", (test) =>
     test
@@ -65,14 +57,14 @@ export default test("Calendar")
       // .child("nextMonth action with disableFuture", (test) =>
       //   test
       //     .step(renderComponent({ date: new Date(), disableFuture: true }))
-      //     .step("try go to next month", () => Calendar().nextMonth())
+      //     .step(Calendar().nextMonth())
       //     .assertion(Calendar().has({ title: "???" }))
       // )
       // TODO Test exception message?
       // .child("setDay action on disabled day", (test) =>
       //   test
       //     .step(renderComponent({ maxDate: new Date("2014-08-18") }))
-      //     .step("select the 20th day", () => calendar.setDay(20))
+      //     .step(calendar.setDay(20))
       //     .assertion(calendar.exists())
       // )
       .child("setDay action with fully custom day render", (test) =>
@@ -84,7 +76,7 @@ export default test("Calendar")
               ),
             })
           )
-          .step("select the 20th day", () => Calendar().setDay(20))
+          .step(Calendar().setDay(20))
           // NOTE There is no way to filter by selected day with a fully custom day render
           // But we still be able do day clicks, just can't test it ¯\_(ツ)_/¯
           .assertion(Calendar("August 2014").exists())
@@ -105,19 +97,19 @@ export default test("Calendar")
       //           }),
       //       }))
       //     )
-      //   // .step("select the 4th day", () => Calendar().setDay(4))
+      //   // .step(Calendar().setDay(4))
       //   // .assertion(Calendar("4 September 2014").exists())
       // )
       .child("nextMonth action with custom icon", (test) =>
         test
           .step(renderComponent({ rightArrowIcon: <span /> }))
-          .step("go to next month", () => calendar.nextMonth())
+          .step(calendar.nextMonth())
           .assertion(Calendar().has({ title: "September 2014" }))
       )
       .child("prevMonth action with custom icon", (test) =>
         test
           .step(renderComponent({ leftArrowIcon: <span /> }))
-          .step("go to prev month", () => calendar.prevMonth())
+          .step(calendar.prevMonth())
           .assertion(Calendar().has({ title: "July 2014" }))
       )
   );

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -20,9 +20,7 @@ export default test("Calendar")
   .child("filter by year", (test) =>
     test.step("render", renderComponent()).assertion(Calendar({ year: "2014" }).exists())
   )
-  .child("filter by selectedDay", (test) =>
-    test.step("render", renderComponent()).assertion(Calendar({ selectedDay: 18 }).exists())
-  )
+  .child("filter by day", (test) => test.step("render", renderComponent()).assertion(Calendar({ day: 18 }).exists()))
   .child("filter by weekDay", (test) =>
     test.step("render", renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists())
   )
@@ -73,15 +71,15 @@ export default test("Calendar")
   //         .assertion(Calendar().has({ title: "August 2013" }))
   //     )
   // )
-  .child("selectDay action", (test) =>
+  .child("setDay action", (test) =>
     test
       .step("render", renderComponent())
-      .step("select the 15th day", () => Calendar().selectDay(15))
+      .step("select the 15th day", () => Calendar().setDay(15))
       .assertion(Calendar("15 August 2014").exists())
   )
   // TODO What should do if user want to click on the disabled `nextMonth` button? Raise exception? Do nothing?
   // TODO How to test an exception with BigTest?
-  // TODO The same for `prevMonth` and `selectDay` and `shouldDisableDate`
+  // TODO The same for `prevMonth` and `setDay` and `shouldDisableDate`
   // TODO Props to test `disableFuture`, `disablePast`, `maxDate`, `minDate`
   // .child("nextMonth action with disableFuture", (test) =>
   //   test
@@ -89,14 +87,14 @@ export default test("Calendar")
   //     .step("try go to next month", () => Calendar().nextMonth())
   //     .assertion(Calendar().has({ title: "???" }))
   // )
-  .child("selectDay action on disabled day", (test) =>
+  .child("setDay action on disabled day", (test) =>
     test
       .step("render", renderComponent({ maxDate: new Date("2014-08-18") }))
-      .step("select the 20th day", () => Calendar().selectDay(20))
+      .step("select the 20th day", () => Calendar().setDay(20))
       // TODO Test exception message?
       .assertion(Calendar("18 August 2014").exists())
   )
-  .child("selectDay action with fully custom day render", (test) =>
+  .child("setDay action with fully custom day render", (test) =>
     test
       .step(
         "render",
@@ -106,13 +104,13 @@ export default test("Calendar")
           ),
         })
       )
-      .step("select the 20th day", () => Calendar().selectDay(20))
+      .step("select the 20th day", () => Calendar().setDay(20))
       // NOTE There is no way to filter by selected day with a fully custom day render
       // But we still be able do day clicks, just can't test it ¯\_(ツ)_/¯
       .assertion(Calendar("August 2014").exists())
   )
   .child(
-    "selectDay action with 'semi-transparent' days",
+    "setDay action with 'semi-transparent' days",
     (test) =>
       test.step(
         "render",
@@ -128,7 +126,7 @@ export default test("Calendar")
         }))
       )
     // TODO But 4th day appears twice :(
-    // .step("select the 4th day", () => Calendar().selectDay(4))
+    // .step("select the 4th day", () => Calendar().setDay(4))
     // .assertion(Calendar("4 September 2014").exists())
   )
   .child("nextMonth action with custom icon", (test) =>
@@ -143,6 +141,3 @@ export default test("Calendar")
       .step("go to prev month", () => Calendar().prevMonth())
       .assertion(Calendar().has({ title: "July 2014" }))
   );
-
-// TODO SetMonth, try to go next/prev month until wanted month, check year. If we went in wrong direction, go back
-// TODO SetYear because we know current year

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -6,145 +6,118 @@ import DateFnsUtils from "@date-io/date-fns";
 
 const renderComponent = getPickerRenderer(Component);
 const CalendarWithUtils = getCalendar(new DateFnsUtils());
+const calendar = Calendar("18 August 2014");
 
 export default test("Calendar")
   .step(Page.visit("/"))
-  .child("filters", (test) =>
+  .child("default render", (test) =>
     test
       .step(renderComponent())
-      .assertion(Calendar("18 August 2014").exists())
-      .assertion(Calendar({ title: "August 2014" }).exists())
-      .assertion(Calendar({ month: "August" }).exists())
-      .assertion(Calendar({ year: "2014" }).exists())
-      .assertion(Calendar({ day: 18 }).exists())
-      .assertion(Calendar({ weekDay: "Mo" }).exists())
-  )
-  // TODO Don't work well on different environments
-  // .child("filter by date", (test) =>
-  //   test.step(renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
-  // )
-  .child("nextMonth action", (test) =>
-    test
-      .step(renderComponent())
-      .step("go to next month", () => Calendar().nextMonth())
-      .assertion(Calendar().has({ title: "September 2014" }))
-  )
-  .child("prevMonth action", (test) =>
-    test
-      .step(renderComponent())
-      .step("go to prev month", () => Calendar().prevMonth())
-      .assertion(Calendar().has({ title: "July 2014" }))
-  )
-  .child("setYear action", (test) =>
-    test
-      .child("in future", (test) =>
-        test
-          .step(renderComponent())
-          .step("go to 2015", () => Calendar().setYear(2015))
-          .assertion(Calendar().has({ title: "August 2015" }))
+      .assertion(calendar.exists())
+      .assertion(calendar.has({ title: "August 2014" }))
+      .assertion(calendar.has({ month: "August" }))
+      .assertion(calendar.has({ year: "2014" }))
+      .assertion(calendar.has({ day: 18 }))
+      .assertion(calendar.has({ weekDay: "Mo" }))
+      // TODO Don't work well on different environments
+      // .assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
+      .child("nextMonth action", (test) =>
+        test.step("go to next month", () => calendar.nextMonth()).assertion(Calendar().has({ title: "September 2014" }))
       )
-      .child("in past", (test) =>
-        test
-          .step(renderComponent())
-          .step("go to 2013", () => Calendar().setYear(2013))
-          .assertion(Calendar().has({ title: "August 2013" }))
+      .child("prevMonth action", (test) =>
+        test.step("go to prev month", () => calendar.prevMonth()).assertion(Calendar().has({ title: "July 2014" }))
       )
-  )
-  .child("setMonth action", (test) =>
-    test
-      .child("in future", (test) =>
+      // NOTE: Using here `Calendar("18 August 2014")` leads to issue where the second nextMonth step throws NoSuchElementError
+      .child("setYear action in future", (test) =>
+        test.step("go to 2015", () => Calendar().setYear(2015)).assertion(Calendar().has({ title: "August 2015" }))
+      )
+      .child("setYear action in past", (test) =>
+        test.step("go to 2013", () => Calendar().setYear(2013)).assertion(Calendar().has({ title: "August 2013" }))
+      )
+      .child("setMonth action in future", (test) =>
         test
-          .step(renderComponent())
           .step("go to September", () => Calendar().setMonth("September"))
           .assertion(Calendar().has({ title: "September 2014" }))
       )
-      .child("in past", (test) =>
-        test
-          .step(renderComponent())
-          .step("go to July", () => Calendar().setMonth("July"))
-          .assertion(Calendar().has({ title: "July 2014" }))
+      .child("setMonth action in past", (test) =>
+        test.step("go to July", () => Calendar().setMonth("July")).assertion(Calendar().has({ title: "July 2014" }))
       )
-  )
-  .child("setMonth action with utils", (test) =>
-    test
-      .child("in future", (test) =>
+      .child("setMonth action with utils in future", (test) =>
         test
-          .step(renderComponent())
           .step("go to September", () => CalendarWithUtils().setMonth("September"))
           .assertion(Calendar().has({ title: "September 2014" }))
       )
-      .child("in past", (test) =>
+      .child("setMonth action with utils in past", (test) =>
         test
-          .step(renderComponent())
           .step("go to July", () => CalendarWithUtils().setMonth("July"))
           .assertion(Calendar().has({ title: "July 2014" }))
       )
-  )
-  .child("setDay action", (test) =>
-    test
-      .step(renderComponent())
-      .step("select the 15th day", () => Calendar().setDay(15))
-      .assertion(Calendar("15 August 2014").exists())
-  )
-  // TODO What should do if user want to click on the disabled `nextMonth` button? Raise exception? Do nothing?
-  // TODO How to test an exception with BigTest?
-  // TODO The same for `prevMonth` and `setDay` and `shouldDisableDate`
-  // TODO Props to test `disableFuture`, `disablePast`, `maxDate`, `minDate`
-  // .child("nextMonth action with disableFuture", (test) =>
-  //   test
-  //     .step(renderComponent({ date: new Date(), disableFuture: true }))
-  //     .step("try go to next month", () => Calendar().nextMonth())
-  //     .assertion(Calendar().has({ title: "???" }))
-  // )
-  // TODO Test exception message?
-  // .child("setDay action on disabled day", (test) =>
-  //   test
-  //     .step(renderComponent({ maxDate: new Date("2014-08-18") }))
-  //     .step("select the 20th day", () => Calendar().setDay(20))
-  //     .assertion(Calendar("18 August 2014").exists())
-  // )
-  .child("setDay action with fully custom day render", (test) =>
-    test
-      .step(
-        renderComponent({
-          renderDay: (day, _selectedDate, dayInCurrentMonth, _dayComponent) => (
-            <button hidden={!dayInCurrentMonth}>{day?.getDate()}</button>
-          ),
-        })
+      .child("setDay action", (test) =>
+        test.step("select the 15th day", () => calendar.setDay(15)).assertion(Calendar("15 August 2014").exists())
       )
-      .step("select the 20th day", () => Calendar().setDay(20))
-      // NOTE There is no way to filter by selected day with a fully custom day render
-      // But we still be able do day clicks, just can't test it ¯\_(ツ)_/¯
-      .assertion(Calendar("August 2014").exists())
   )
-  // TODO But 4th day appears twice :(
-  // .child(
-  //   "setDay action with 'semi-transparent' days",
-  //   (test) =>
-  //     test.step(
-  //       // NOTE: Another `cool` thing we can render days from prev/next months and they are clickable
-  //       renderComponent((onChange) => ({
-  //         renderDay: (day, _selectedDate, dayInCurrentMonth, dayComponent) =>
-  //           cloneElement(dayComponent, {
-  //             hidden: false,
-  //             ...(dayInCurrentMonth
-  //               ? undefined
-  //               : { style: { opacity: "0.5" }, onClick: () => onChange?.(day as Date) }),
-  //           }),
-  //       }))
-  //     )
-  //   // .step("select the 4th day", () => Calendar().setDay(4))
-  //   // .assertion(Calendar("4 September 2014").exists())
-  // )
-  .child("nextMonth action with custom icon", (test) =>
+  .child("custom renders", (test) =>
     test
-      .step(renderComponent({ rightArrowIcon: <span /> }))
-      .step("go to next month", () => Calendar().nextMonth())
-      .assertion(Calendar().has({ title: "September 2014" }))
-  )
-  .child("prevMonth action with custom icon", (test) =>
-    test
-      .step(renderComponent({ leftArrowIcon: <span /> }))
-      .step("go to prev month", () => Calendar().prevMonth())
-      .assertion(Calendar().has({ title: "July 2014" }))
+      // TODO What should do if user want to click on the disabled `nextMonth` button? Raise exception? Do nothing?
+      // TODO How to test an exception with BigTest?
+      // TODO The same for `prevMonth` and `setDay` and `shouldDisableDate`
+      // TODO Props to test `disableFuture`, `disablePast`, `maxDate`, `minDate`
+      // .child("nextMonth action with disableFuture", (test) =>
+      //   test
+      //     .step(renderComponent({ date: new Date(), disableFuture: true }))
+      //     .step("try go to next month", () => Calendar().nextMonth())
+      //     .assertion(Calendar().has({ title: "???" }))
+      // )
+      // TODO Test exception message?
+      // .child("setDay action on disabled day", (test) =>
+      //   test
+      //     .step(renderComponent({ maxDate: new Date("2014-08-18") }))
+      //     .step("select the 20th day", () => calendar.setDay(20))
+      //     .assertion(calendar.exists())
+      // )
+      .child("setDay action with fully custom day render", (test) =>
+        test
+          .step(
+            renderComponent({
+              renderDay: (day, _selectedDate, dayInCurrentMonth, _dayComponent) => (
+                <button hidden={!dayInCurrentMonth}>{day?.getDate()}</button>
+              ),
+            })
+          )
+          .step("select the 20th day", () => Calendar().setDay(20))
+          // NOTE There is no way to filter by selected day with a fully custom day render
+          // But we still be able do day clicks, just can't test it ¯\_(ツ)_/¯
+          .assertion(Calendar("August 2014").exists())
+      )
+      // TODO But 4th day appears twice :(
+      // .child(
+      //   "setDay action with 'semi-transparent' days",
+      //   (test) =>
+      //     test.step(
+      //       // NOTE: Another `cool` thing we can render days from prev/next months and they are clickable
+      //       renderComponent((onChange) => ({
+      //         renderDay: (day, _selectedDate, dayInCurrentMonth, dayComponent) =>
+      //           cloneElement(dayComponent, {
+      //             hidden: false,
+      //             ...(dayInCurrentMonth
+      //               ? undefined
+      //               : { style: { opacity: "0.5" }, onClick: () => onChange?.(day as Date) }),
+      //           }),
+      //       }))
+      //     )
+      //   // .step("select the 4th day", () => Calendar().setDay(4))
+      //   // .assertion(Calendar("4 September 2014").exists())
+      // )
+      .child("nextMonth action with custom icon", (test) =>
+        test
+          .step(renderComponent({ rightArrowIcon: <span /> }))
+          .step("go to next month", () => calendar.nextMonth())
+          .assertion(Calendar().has({ title: "September 2014" }))
+      )
+      .child("prevMonth action with custom icon", (test) =>
+        test
+          .step(renderComponent({ leftArrowIcon: <span /> }))
+          .step("go to prev month", () => calendar.prevMonth())
+          .assertion(Calendar().has({ title: "July 2014" }))
+      )
   );

--- a/test/calendar.test.tsx
+++ b/test/calendar.test.tsx
@@ -1,9 +1,11 @@
 import { test, Page } from "bigtest";
 import { Calendar as Component } from "@material-ui/pickers";
-import { Calendar } from "../src";
+import { Calendar, getCalendar } from "../src";
 import { getPickerRenderer } from "./helpers";
+import DateFnsUtils from "@date-io/date-fns";
 
 const renderComponent = getPickerRenderer(Component);
+const CalendarWithUtils = getCalendar(new DateFnsUtils());
 
 export default test("Calendar")
   .step(Page.visit("/"))
@@ -23,6 +25,15 @@ export default test("Calendar")
   .child("filter by weekDay", (test) =>
     test.step("render", renderComponent()).assertion(Calendar({ weekDay: "Mo" }).exists())
   )
+  // NOTE: Doesn't work
+  // │ ERROR did not find MUI Calendar with date "2014-08-18T00:00:00.000Z", did you mean one of:
+  // │
+  // │ ┃ date: "2014-08-18T00:00:00.000Z" ┃
+  // │ ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┫
+  // │ ┃ ⨯ "2014-08-18T22:00:00.000Z"     ┃
+  // .child("filter by date", (test) =>
+  //   test.step("render", renderComponent()).assertion(CalendarWithUtils({ date: new Date("2014-08-18") }).exists())
+  // )
   .child("nextMonth action", (test) =>
     test
       .step("render", renderComponent())
@@ -62,6 +73,21 @@ export default test("Calendar")
         test
           .step("render", renderComponent())
           .step("go to July", () => Calendar().setMonth("July"))
+          .assertion(Calendar().has({ title: "July 2014" }))
+      )
+  )
+  .child("setMonth action with utils", (test) =>
+    test
+      .child("in future", (test) =>
+        test
+          .step("render", renderComponent())
+          .step("go to September", () => CalendarWithUtils().setMonth("September"))
+          .assertion(Calendar().has({ title: "September 2014" }))
+      )
+      .child("in past", (test) =>
+        test
+          .step("render", renderComponent())
+          .step("go to July", () => CalendarWithUtils().setMonth("July"))
           .assertion(Calendar().has({ title: "July 2014" }))
       )
   )

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -1,24 +1,22 @@
 import { test, Page } from "bigtest";
 import { Body, Checkbox } from "../src/index";
 import { Checkbox as Component, FormControlLabel } from "@material-ui/core";
-import { render } from "./helpers";
+import { getComponentRenderer, render } from "./helpers";
+
+const renderComponent = getComponentRenderer(Component, {}, ({ props, children }) => (
+  <FormControlLabel label="locator" control={children(props)} />
+));
 
 export default test("Checkbox")
   .step(Page.visit("/"))
-  .child("test `filter` by locator", (test) =>
-    test
-      .step(render(<FormControlLabel label="locator" control={<Component />} />))
-      .assertion(Checkbox("locator").exists())
-  )
+  .child("test `filter` by locator", (test) => test.step(renderComponent()).assertion(Checkbox("locator").exists()))
   .child("test `filter` by checked", (test) =>
     test
       .step(render(<FormControlLabel label="checked" checked control={<Component />} />))
       .assertion(Checkbox({ checked: true }).exists())
   )
   .child("test `filter` by indeterminate", (test) =>
-    test
-      .step(render(<FormControlLabel label="indeterminate" control={<Component indeterminate />} />))
-      .assertion(Checkbox({ indeterminate: true }).exists())
+    test.step(renderComponent({ indeterminate: true })).assertion(Checkbox({ indeterminate: true }).exists())
   )
   .child("test `filter` by disabled", (test) =>
     test
@@ -30,7 +28,7 @@ export default test("Checkbox")
   )
   .child("test `click` action", (test) =>
     test
-      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(renderComponent())
       .assertion(Checkbox().is({ checked: false, focused: false }))
       .child("click and assert", (test) =>
         test.step(Checkbox().click()).assertion(Checkbox().is({ checked: true, focused: true }))
@@ -38,25 +36,25 @@ export default test("Checkbox")
   )
   .child("test `focus` action", (test) =>
     test
-      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(renderComponent())
       .assertion(Checkbox().is({ focused: false }))
       .child("focus and assert", (test) => test.step(Checkbox().focus()).assertion(Checkbox().is({ focused: true })))
   )
   .child("test `blur` action", (test) =>
     test
-      .step(render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
+      .step(renderComponent({ autoFocus: true }))
       .assertion(Checkbox().is({ focused: true }))
       .child("blur and assert", (test) => test.step(Checkbox().blur()).assertion(Checkbox().is({ focused: false })))
   )
   .child("test `check` action", (test) =>
     test
-      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(renderComponent())
       .assertion(Checkbox().is({ checked: false }))
       .child("check and assert", (test) => test.step(Checkbox().check()).assertion(Checkbox().is({ checked: true })))
   )
   .child("test `uncheck` action", (test) =>
     test
-      .step(render(<FormControlLabel label="checkbox" control={<Component defaultChecked />} />))
+      .step(renderComponent({ defaultChecked: true }))
       .assertion(Checkbox().is({ checked: true }))
       .child("uncheck and assert", (test) =>
         test.step(Checkbox().uncheck()).assertion(Checkbox().is({ checked: false }))
@@ -64,7 +62,7 @@ export default test("Checkbox")
   )
   .child("test `toggle` action", (test) =>
     test
-      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(renderComponent())
       .assertion(Checkbox().is({ checked: false }))
       .child("toggle twice", (test) =>
         test
@@ -75,7 +73,7 @@ export default test("Checkbox")
   )
   .child("test click outside", (test) =>
     test
-      .step(render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
+      .step(renderComponent({ autoFocus: true }))
       .step("click to the body", () => Body().click())
       .assertion(Checkbox().is({ focused: false }))
   );

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -1,5 +1,5 @@
 import { test, Page } from "bigtest";
-import { Body, CheckBox } from "../src/index";
+import { Body, Checkbox } from "../src/index";
 import { Checkbox as Component, FormControlLabel } from "@material-ui/core";
 import { render } from "./helpers";
 
@@ -8,74 +8,74 @@ export default test("Checkbox")
   .child("test `filter` by locator", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="locator" control={<Component />} />))
-      .assertion(CheckBox("locator").exists())
+      .assertion(Checkbox("locator").exists())
   )
   .child("test `filter` by checked", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checked" checked control={<Component />} />))
-      .assertion(CheckBox({ checked: true }).exists())
+      .assertion(Checkbox({ checked: true }).exists())
   )
   .child("test `filter` by indeterminate", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="indeterminate" control={<Component indeterminate />} />))
-      .assertion(CheckBox({ indeterminate: true }).exists())
+      .assertion(Checkbox({ indeterminate: true }).exists())
   )
   .child("test `filter` by disabled", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="disabled" disabled control={<Component />} />))
-      .assertion(CheckBox({ disabled: true }).exists())
+      .assertion(Checkbox({ disabled: true }).exists())
   )
   .child("test `filter` by visible", (test) =>
-    test.step("render", () => render(<Component />)).assertion(CheckBox({ visible: false }).exists())
+    test.step("render", () => render(<Component />)).assertion(Checkbox({ visible: false }).exists())
   )
   .child("test `click` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
-      .assertion(CheckBox().is({ checked: false, focused: false }))
+      .assertion(Checkbox().is({ checked: false, focused: false }))
       .child("click and assert", (test) =>
-        test.step(CheckBox().click()).assertion(CheckBox().is({ checked: true, focused: true }))
+        test.step(Checkbox().click()).assertion(Checkbox().is({ checked: true, focused: true }))
       )
   )
   .child("test `focus` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
-      .assertion(CheckBox().is({ focused: false }))
-      .child("focus and assert", (test) => test.step(CheckBox().focus()).assertion(CheckBox().is({ focused: true })))
+      .assertion(Checkbox().is({ focused: false }))
+      .child("focus and assert", (test) => test.step(Checkbox().focus()).assertion(Checkbox().is({ focused: true })))
   )
   .child("test `blur` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
-      .assertion(CheckBox().is({ focused: true }))
-      .child("blur and assert", (test) => test.step(CheckBox().blur()).assertion(CheckBox().is({ focused: false })))
+      .assertion(Checkbox().is({ focused: true }))
+      .child("blur and assert", (test) => test.step(Checkbox().blur()).assertion(Checkbox().is({ focused: false })))
   )
   .child("test `check` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
-      .assertion(CheckBox().is({ checked: false }))
-      .child("check and assert", (test) => test.step(CheckBox().check()).assertion(CheckBox().is({ checked: true })))
+      .assertion(Checkbox().is({ checked: false }))
+      .child("check and assert", (test) => test.step(Checkbox().check()).assertion(Checkbox().is({ checked: true })))
   )
   .child("test `uncheck` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Component defaultChecked />} />))
-      .assertion(CheckBox().is({ checked: true }))
+      .assertion(Checkbox().is({ checked: true }))
       .child("uncheck and assert", (test) =>
-        test.step(CheckBox().uncheck()).assertion(CheckBox().is({ checked: false }))
+        test.step(Checkbox().uncheck()).assertion(Checkbox().is({ checked: false }))
       )
   )
   .child("test `toggle` action", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
-      .assertion(CheckBox().is({ checked: false }))
+      .assertion(Checkbox().is({ checked: false }))
       .child("toggle twice", (test) =>
         test
-          .step(CheckBox().toggle())
-          .assertion(CheckBox().is({ checked: true }))
-          .child("second toggle", (test) => test.step(CheckBox().toggle()).assertion(CheckBox().is({ checked: false })))
+          .step(Checkbox().toggle())
+          .assertion(Checkbox().is({ checked: true }))
+          .child("second toggle", (test) => test.step(Checkbox().toggle()).assertion(Checkbox().is({ checked: false })))
       )
   )
   .child("test click outside", (test) =>
     test
       .step("render", () => render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
       .step("click to the body", () => Body().click())
-      .assertion(CheckBox().is({ focused: false }))
+      .assertion(Checkbox().is({ focused: false }))
   );

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -7,30 +7,30 @@ export default test("Checkbox")
   .step(Page.visit("/"))
   .child("test `filter` by locator", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="locator" control={<Component />} />))
+      .step(render(<FormControlLabel label="locator" control={<Component />} />))
       .assertion(Checkbox("locator").exists())
   )
   .child("test `filter` by checked", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checked" checked control={<Component />} />))
+      .step(render(<FormControlLabel label="checked" checked control={<Component />} />))
       .assertion(Checkbox({ checked: true }).exists())
   )
   .child("test `filter` by indeterminate", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="indeterminate" control={<Component indeterminate />} />))
+      .step(render(<FormControlLabel label="indeterminate" control={<Component indeterminate />} />))
       .assertion(Checkbox({ indeterminate: true }).exists())
   )
   .child("test `filter` by disabled", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="disabled" disabled control={<Component />} />))
+      .step(render(<FormControlLabel label="disabled" disabled control={<Component />} />))
       .assertion(Checkbox({ disabled: true }).exists())
   )
   .child("test `filter` by visible", (test) =>
-    test.step("render", () => render(<Component />)).assertion(Checkbox({ visible: false }).exists())
+    test.step(render(<Component />)).assertion(Checkbox({ visible: false }).exists())
   )
   .child("test `click` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
       .assertion(Checkbox().is({ checked: false, focused: false }))
       .child("click and assert", (test) =>
         test.step(Checkbox().click()).assertion(Checkbox().is({ checked: true, focused: true }))
@@ -38,25 +38,25 @@ export default test("Checkbox")
   )
   .child("test `focus` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
       .assertion(Checkbox().is({ focused: false }))
       .child("focus and assert", (test) => test.step(Checkbox().focus()).assertion(Checkbox().is({ focused: true })))
   )
   .child("test `blur` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
+      .step(render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
       .assertion(Checkbox().is({ focused: true }))
       .child("blur and assert", (test) => test.step(Checkbox().blur()).assertion(Checkbox().is({ focused: false })))
   )
   .child("test `check` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
       .assertion(Checkbox().is({ checked: false }))
       .child("check and assert", (test) => test.step(Checkbox().check()).assertion(Checkbox().is({ checked: true })))
   )
   .child("test `uncheck` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component defaultChecked />} />))
+      .step(render(<FormControlLabel label="checkbox" control={<Component defaultChecked />} />))
       .assertion(Checkbox().is({ checked: true }))
       .child("uncheck and assert", (test) =>
         test.step(Checkbox().uncheck()).assertion(Checkbox().is({ checked: false }))
@@ -64,7 +64,7 @@ export default test("Checkbox")
   )
   .child("test `toggle` action", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component />} />))
+      .step(render(<FormControlLabel label="checkbox" control={<Component />} />))
       .assertion(Checkbox().is({ checked: false }))
       .child("toggle twice", (test) =>
         test
@@ -75,7 +75,7 @@ export default test("Checkbox")
   )
   .child("test click outside", (test) =>
     test
-      .step("render", () => render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
+      .step(render(<FormControlLabel label="checkbox" control={<Component autoFocus />} />))
       .step("click to the body", () => Body().click())
       .assertion(Checkbox().is({ focused: false }))
   );

--- a/test/checkbox.test.tsx
+++ b/test/checkbox.test.tsx
@@ -4,76 +4,60 @@ import { Checkbox as Component, FormControlLabel } from "@material-ui/core";
 import { getComponentRenderer, render } from "./helpers";
 
 const renderComponent = getComponentRenderer(Component, {}, ({ props, children }) => (
-  <FormControlLabel label="locator" control={children(props)} />
+  <FormControlLabel label="checkbox" control={children(props)} />
 ));
+const checkbox = Checkbox("checkbox");
 
 export default test("Checkbox")
   .step(Page.visit("/"))
-  .child("test `filter` by locator", (test) => test.step(renderComponent()).assertion(Checkbox("locator").exists()))
-  .child("test `filter` by checked", (test) =>
+  .child("default render", (test) =>
     test
-      .step(render(<FormControlLabel label="checked" checked control={<Component />} />))
-      .assertion(Checkbox({ checked: true }).exists())
+      .step(renderComponent())
+      .assertion(checkbox.exists())
+      .assertion(Checkbox().is({ checked: false }))
+      .assertion(Checkbox().is({ focused: false }))
+      .assertion(Checkbox({ disabled: false }).exists())
+      .child("test `click` action", (test) =>
+        test.step(checkbox.click()).assertion(checkbox.is({ checked: true, focused: true }))
+      )
+      .child("test `focus` action", (test) => test.step(checkbox.focus()).assertion(checkbox.is({ focused: true })))
+      .child("test `check` action", (test) => test.step(checkbox.check()).assertion(checkbox.is({ checked: true })))
+      .child("test `toggle` action", (test) =>
+        test
+          .step(checkbox.toggle())
+          .assertion(checkbox.is({ checked: true }))
+          .child("toggle twice", (test) => test.step(checkbox.toggle()).assertion(checkbox.is({ checked: false })))
+      )
   )
   .child("test `filter` by indeterminate", (test) =>
-    test.step(renderComponent({ indeterminate: true })).assertion(Checkbox({ indeterminate: true }).exists())
+    test.step(renderComponent({ indeterminate: true })).assertion(checkbox.is({ indeterminate: true }))
+  )
+  .child("test `filter` by checked", (test) =>
+    test
+      .step(render(<FormControlLabel label="checkbox" checked control={<Component />} />))
+      .assertion(checkbox.is({ checked: true }))
   )
   .child("test `filter` by disabled", (test) =>
     test
-      .step(render(<FormControlLabel label="disabled" disabled control={<Component />} />))
+      .step(render(<FormControlLabel label="checkbox" disabled control={<Component />} />))
       .assertion(Checkbox({ disabled: true }).exists())
   )
   .child("test `filter` by visible", (test) =>
     test.step(render(<Component />)).assertion(Checkbox({ visible: false }).exists())
   )
-  .child("test `click` action", (test) =>
-    test
-      .step(renderComponent())
-      .assertion(Checkbox().is({ checked: false, focused: false }))
-      .child("click and assert", (test) =>
-        test.step(Checkbox().click()).assertion(Checkbox().is({ checked: true, focused: true }))
-      )
-  )
-  .child("test `focus` action", (test) =>
-    test
-      .step(renderComponent())
-      .assertion(Checkbox().is({ focused: false }))
-      .child("focus and assert", (test) => test.step(Checkbox().focus()).assertion(Checkbox().is({ focused: true })))
-  )
-  .child("test `blur` action", (test) =>
-    test
-      .step(renderComponent({ autoFocus: true }))
-      .assertion(Checkbox().is({ focused: true }))
-      .child("blur and assert", (test) => test.step(Checkbox().blur()).assertion(Checkbox().is({ focused: false })))
-  )
-  .child("test `check` action", (test) =>
-    test
-      .step(renderComponent())
-      .assertion(Checkbox().is({ checked: false }))
-      .child("check and assert", (test) => test.step(Checkbox().check()).assertion(Checkbox().is({ checked: true })))
-  )
+
   .child("test `uncheck` action", (test) =>
     test
       .step(renderComponent({ defaultChecked: true }))
-      .assertion(Checkbox().is({ checked: true }))
-      .child("uncheck and assert", (test) =>
-        test.step(Checkbox().uncheck()).assertion(Checkbox().is({ checked: false }))
-      )
+      .step(checkbox.uncheck())
+      .assertion(checkbox.is({ checked: false }))
   )
-  .child("test `toggle` action", (test) =>
-    test
-      .step(renderComponent())
-      .assertion(Checkbox().is({ checked: false }))
-      .child("toggle twice", (test) =>
-        test
-          .step(Checkbox().toggle())
-          .assertion(Checkbox().is({ checked: true }))
-          .child("second toggle", (test) => test.step(Checkbox().toggle()).assertion(Checkbox().is({ checked: false })))
-      )
-  )
-  .child("test click outside", (test) =>
+  .child("autoFocus", (test) =>
     test
       .step(renderComponent({ autoFocus: true }))
-      .step("click to the body", () => Body().click())
-      .assertion(Checkbox().is({ focused: false }))
+      .assertion(checkbox.is({ focused: true }))
+      .child("test `blur` action", (test) => test.step(checkbox.blur()).assertion(checkbox.is({ focused: false })))
+      .child("test click outside", (test) =>
+        test.step("click to the body", () => Body().click()).assertion(checkbox.is({ focused: false }))
+      )
   );

--- a/test/datefield.test.tsx
+++ b/test/datefield.test.tsx
@@ -1,0 +1,37 @@
+import { Page, test } from "bigtest";
+import { TextField as Component } from "@material-ui/core";
+import { DateField } from "../src";
+import { getComponentRenderer } from "./helpers";
+
+const renderComponent = getComponentRenderer(Component, { id: "datefield", label: "datefield", type: "date" });
+const datefield = DateField("datefield");
+
+export default test("DateField")
+  .step(Page.visit("/"))
+  .child("default", (test) =>
+    test
+      .step(renderComponent())
+      .assertion(datefield.has({ value: "" }))
+      .child("fillIn string", (test) =>
+        test
+          .step(datefield.fillIn("2014-08-18"))
+          .assertion(datefield.has({ value: "2014-08-18" }))
+          .assertion(datefield.has({ date: new Date("2014-08-18") }))
+          .assertion(datefield.has({ timestamp: new Date("2014-08-18").getTime() }))
+      )
+      .child("fillIn date", (test) =>
+        test.step(datefield.fillIn(new Date("2014-08-18"))).assertion(datefield.has({ value: "2014-08-18" }))
+      )
+  )
+  .child("min/max", (test) =>
+    test
+      .step(renderComponent({ inputProps: { min: "2013-07-15", max: "2015-09-21" } }))
+      .step(datefield.fillIn("2014-08-18"))
+      .assertion(datefield.has({ value: "2014-08-18" }))
+      .child("before min", (test) =>
+        test.step(datefield.fillIn("2012-06-13")).assertion(datefield.has({ value: "2012-06-13" }))
+      )
+      .child("after max", (test) =>
+        test.step(datefield.fillIn("2016-10-26")).assertion(datefield.has({ value: "2016-10-26" }))
+      )
+  );

--- a/test/datepicker.test.tsx
+++ b/test/datepicker.test.tsx
@@ -1,0 +1,109 @@
+import { Page, test, TestBuilder } from "bigtest";
+import { DatePicker as Component } from "@material-ui/pickers";
+import { getPickerRenderer } from "./helpers";
+import { DatePicker } from "../src";
+import { ComponentProps } from "react";
+
+const renderComponent = getPickerRenderer(Component);
+
+const actionTests = (props?: Partial<ComponentProps<typeof Component>>) => (
+  test: TestBuilder<Record<string, unknown>>
+) => {
+  test = test
+    .child("setDay action", (test) =>
+      test
+        .step("render", renderComponent(props))
+        .step("set 21st day", () => DatePicker().setDay(21))
+        .assertion(DatePicker().has({ value: "August 21st" }))
+    )
+    .child("setMonth action", (test) =>
+      test
+        .step("render", renderComponent(props))
+        .step("set September", () => DatePicker().setMonth("September"))
+        .assertion(DatePicker().has({ value: "September 18th" }))
+    )
+    .child("setYear action", (test) =>
+      test
+        .step("render", renderComponent({ ...props, format: "MM/dd/yyyy" }))
+        .step("set 2015", () => DatePicker().setYear(2015))
+        .assertion(DatePicker().has({ value: "08/18/2015" }))
+    )
+    .child("setDate action", (test) =>
+      test
+        .step("render", renderComponent({ ...props, format: "MM/dd/yyyy" }))
+        .step("set September 21th 2015", () => DatePicker().setDate({ day: 21, month: "September", year: 2015 }))
+        .assertion(DatePicker().has({ value: "09/21/2015" }))
+    );
+
+  if (props?.variant != "inline") {
+    test = test
+      .child("setToday action", (test) =>
+        test
+          .step("render", renderComponent({ ...props, format: "yyyy-MM-dd", showTodayButton: true, todayLabel: "Now" }))
+          .step("set today", () => DatePicker().setToday("Now"))
+          .assertion(DatePicker().has({ value: new Date().toISOString().replace(/T.*$/, "") }))
+      )
+      .child("clear action", (test) =>
+        test
+          .step("render", renderComponent({ ...props, clearable: true, clearLabel: "Empty" }))
+          .step("clear", () => DatePicker().clear("Empty"))
+          .assertion(DatePicker().has({ value: "" }))
+      );
+  }
+
+  return test;
+};
+
+export default test("DatePicker")
+  .step(Page.visit("/"))
+  .child("filter by locator", (test) =>
+    test.step("render", renderComponent()).assertion(DatePicker("2014-08-18").exists())
+  )
+  .child("filter by value", (test) =>
+    test.step("render", renderComponent()).assertion(DatePicker({ value: "August 18th" }).exists())
+  )
+  .child("filter by value with format", (test) =>
+    test
+      .step("render", renderComponent({ format: "MM/dd/yyyy" }))
+      .assertion(DatePicker({ value: "08/18/2014" }).exists())
+  )
+  .child("filter by valid", (test) =>
+    test.step("render", renderComponent({ value: "1234-56-78" })).assertion(DatePicker({ valid: false }).exists())
+  )
+  .child("filter by disabled", (test) =>
+    test.step("render", renderComponent({ disabled: true })).assertion(DatePicker({ disabled: true }).exists())
+  )
+  .child("filter by visible", (test) =>
+    test
+      .step("render", renderComponent({ style: { visibility: "hidden" } }))
+      .assertion(DatePicker({ visible: false }).exists())
+  )
+  .child("filter by readOnly", (test) =>
+    test.step("render", renderComponent({ readOnly: true })).assertion(DatePicker({ readOnly: true }).exists())
+  )
+  .child("filter by format", (test) =>
+    test
+      .step("render", renderComponent({ format: "MM/dd/yyyy" }))
+      .assertion(DatePicker({ format: "MM/dd/yyyy" }).exists())
+  )
+  .child("default", actionTests())
+  .child("orientation='landscape'", actionTests({ orientation: "landscape" }))
+  .child("variant='inline'", actionTests({ variant: "inline" }))
+  .child("autoOk", actionTests({ autoOk: true }))
+  .child("disableToolbar", actionTests({ disableToolbar: true }));
+
+// TODO views={['month', 'date']}
+
+// openTo - "date" | "year" | "month"
+// variant - "dialog" | "inline" | "static"
+// views - Array<"year" | "date" | "month">
+
+//inputVariant - string
+//invalidDateMessage - react node
+//emptyLabel - string
+//maxDateMessage, minDateMessage - react node
+//TextFieldComponent ??
+//ToolbarComponent ??
+
+// mask for keyboard :(
+// TODO DateTimePicker

--- a/test/datepicker.test.tsx
+++ b/test/datepicker.test.tsx
@@ -56,9 +56,11 @@ const actionTests = (props?: Partial<ComponentProps<typeof Component>>) => (
 
 export default test("DatePicker")
   .step(Page.visit("/"))
-  .child("filter by locator", (test) => test.step(renderComponent()).assertion(DatePicker("2014-08-18").exists()))
-  .child("filter by value", (test) =>
-    test.step(renderComponent()).assertion(DatePicker({ value: "August 18th" }).exists())
+  .child("filter by locator and value", (test) =>
+    test
+      .step(renderComponent())
+      .assertion(DatePicker("2014-08-18").exists())
+      .assertion(DatePicker({ value: "August 18th" }).exists())
   )
   .child("filter by value with format", (test) =>
     test.step(renderComponent({ format: "MM/dd/yyyy" })).assertion(DatePicker({ value: "08/18/2014" }).exists())

--- a/test/datepicker.test.tsx
+++ b/test/datepicker.test.tsx
@@ -12,25 +12,25 @@ const actionTests = (props?: Partial<ComponentProps<typeof Component>>) => (
   test = test
     .child("setDay action", (test) =>
       test
-        .step("render", renderComponent(props))
+        .step(renderComponent(props))
         .step("set 21st day", () => DatePicker().setDay(21))
         .assertion(DatePicker().has({ value: "August 21st" }))
     )
     .child("setMonth action", (test) =>
       test
-        .step("render", renderComponent(props))
+        .step(renderComponent(props))
         .step("set September", () => DatePicker().setMonth("September"))
         .assertion(DatePicker().has({ value: "September 18th" }))
     )
     .child("setYear action", (test) =>
       test
-        .step("render", renderComponent({ ...props, format: "MM/dd/yyyy" }))
+        .step(renderComponent({ ...props, format: "MM/dd/yyyy" }))
         .step("set 2015", () => DatePicker().setYear(2015))
         .assertion(DatePicker().has({ value: "08/18/2015" }))
     )
     .child("setDate action", (test) =>
       test
-        .step("render", renderComponent({ ...props, format: "MM/dd/yyyy" }))
+        .step(renderComponent({ ...props, format: "MM/dd/yyyy" }))
         .step("set September 21th 2015", () => DatePicker().setDate({ day: 21, month: "September", year: 2015 }))
         .assertion(DatePicker().has({ value: "09/21/2015" }))
     );
@@ -39,13 +39,13 @@ const actionTests = (props?: Partial<ComponentProps<typeof Component>>) => (
     test = test
       .child("setToday action", (test) =>
         test
-          .step("render", renderComponent({ ...props, format: "yyyy-MM-dd", showTodayButton: true, todayLabel: "Now" }))
+          .step(renderComponent({ ...props, format: "yyyy-MM-dd", showTodayButton: true, todayLabel: "Now" }))
           .step("set today", () => DatePicker().setToday("Now"))
           .assertion(DatePicker().has({ value: new Date().toISOString().replace(/T.*$/, "") }))
       )
       .child("clear action", (test) =>
         test
-          .step("render", renderComponent({ ...props, clearable: true, clearLabel: "Empty" }))
+          .step(renderComponent({ ...props, clearable: true, clearLabel: "Empty" }))
           .step("clear", () => DatePicker().clear("Empty"))
           .assertion(DatePicker().has({ value: "" }))
       );
@@ -56,35 +56,27 @@ const actionTests = (props?: Partial<ComponentProps<typeof Component>>) => (
 
 export default test("DatePicker")
   .step(Page.visit("/"))
-  .child("filter by locator", (test) =>
-    test.step("render", renderComponent()).assertion(DatePicker("2014-08-18").exists())
-  )
+  .child("filter by locator", (test) => test.step(renderComponent()).assertion(DatePicker("2014-08-18").exists()))
   .child("filter by value", (test) =>
-    test.step("render", renderComponent()).assertion(DatePicker({ value: "August 18th" }).exists())
+    test.step(renderComponent()).assertion(DatePicker({ value: "August 18th" }).exists())
   )
   .child("filter by value with format", (test) =>
-    test
-      .step("render", renderComponent({ format: "MM/dd/yyyy" }))
-      .assertion(DatePicker({ value: "08/18/2014" }).exists())
+    test.step(renderComponent({ format: "MM/dd/yyyy" })).assertion(DatePicker({ value: "08/18/2014" }).exists())
   )
   .child("filter by valid", (test) =>
-    test.step("render", renderComponent({ value: "1234-56-78" })).assertion(DatePicker({ valid: false }).exists())
+    test.step(renderComponent({ value: "1234-56-78" })).assertion(DatePicker({ valid: false }).exists())
   )
   .child("filter by disabled", (test) =>
-    test.step("render", renderComponent({ disabled: true })).assertion(DatePicker({ disabled: true }).exists())
+    test.step(renderComponent({ disabled: true })).assertion(DatePicker({ disabled: true }).exists())
   )
   .child("filter by visible", (test) =>
-    test
-      .step("render", renderComponent({ style: { visibility: "hidden" } }))
-      .assertion(DatePicker({ visible: false }).exists())
+    test.step(renderComponent({ style: { visibility: "hidden" } })).assertion(DatePicker({ visible: false }).exists())
   )
   .child("filter by readOnly", (test) =>
-    test.step("render", renderComponent({ readOnly: true })).assertion(DatePicker({ readOnly: true }).exists())
+    test.step(renderComponent({ readOnly: true })).assertion(DatePicker({ readOnly: true }).exists())
   )
   .child("filter by format", (test) =>
-    test
-      .step("render", renderComponent({ format: "MM/dd/yyyy" }))
-      .assertion(DatePicker({ format: "MM/dd/yyyy" }).exists())
+    test.step(renderComponent({ format: "MM/dd/yyyy" })).assertion(DatePicker({ format: "MM/dd/yyyy" }).exists())
   )
   .child("default", actionTests())
   .child("orientation='landscape'", actionTests({ orientation: "landscape" }))

--- a/test/datepicker.test.tsx
+++ b/test/datepicker.test.tsx
@@ -13,25 +13,25 @@ const actionTests = (props?: Partial<ComponentProps<typeof Component>>) => (
     .child("setDay action", (test) =>
       test
         .step(renderComponent(props))
-        .step("set 21st day", () => DatePicker().setDay(21))
+        .step(DatePicker().setDay(21))
         .assertion(DatePicker().has({ value: "August 21st" }))
     )
     .child("setMonth action", (test) =>
       test
         .step(renderComponent(props))
-        .step("set September", () => DatePicker().setMonth("September"))
+        .step(DatePicker().setMonth("September"))
         .assertion(DatePicker().has({ value: "September 18th" }))
     )
     .child("setYear action", (test) =>
       test
         .step(renderComponent({ ...props, format: "MM/dd/yyyy" }))
-        .step("set 2015", () => DatePicker().setYear(2015))
+        .step(DatePicker().setYear(2015))
         .assertion(DatePicker().has({ value: "08/18/2015" }))
     )
     .child("setDate action", (test) =>
       test
         .step(renderComponent({ ...props, format: "MM/dd/yyyy" }))
-        .step("set September 21th 2015", () => DatePicker().setDate({ day: 21, month: "September", year: 2015 }))
+        .step(DatePicker().setDate({ day: 21, month: "September", year: 2015 }))
         .assertion(DatePicker().has({ value: "09/21/2015" }))
     );
 
@@ -40,13 +40,13 @@ const actionTests = (props?: Partial<ComponentProps<typeof Component>>) => (
       .child("setToday action", (test) =>
         test
           .step(renderComponent({ ...props, format: "yyyy-MM-dd", showTodayButton: true, todayLabel: "Now" }))
-          .step("set today", () => DatePicker().setToday("Now"))
+          .step(DatePicker().setToday("Now"))
           .assertion(DatePicker().has({ value: new Date().toISOString().replace(/T.*$/, "") }))
       )
       .child("clear action", (test) =>
         test
           .step(renderComponent({ ...props, clearable: true, clearLabel: "Empty" }))
-          .step("clear", () => DatePicker().clear("Empty"))
+          .step(DatePicker().clear("Empty"))
           .assertion(DatePicker().has({ value: "" }))
       );
   }

--- a/test/datetimefield.test.tsx
+++ b/test/datetimefield.test.tsx
@@ -1,0 +1,38 @@
+import { Page, test } from "bigtest";
+import { TextField as Component } from "@material-ui/core";
+import { DateTimeField } from "../src";
+import { getComponentRenderer } from "./helpers";
+
+const renderComponent = getComponentRenderer(Component, {
+  id: "datetimefield",
+  label: "datetimefield",
+  type: "datetime-local",
+});
+const datetimefield = DateTimeField("datetimefield");
+
+export default test("DateTimeField")
+  .step(Page.visit("/"))
+  .child("default", (test) =>
+    test
+      .step(renderComponent())
+      .assertion(datetimefield.has({ value: "" }))
+      .child("fillIn string", (test) =>
+        test
+          .step(datetimefield.fillIn("2014-08-18T09:13:37.512"))
+          .assertion(datetimefield.has({ value: "2014-08-18T09:13:37.512" }))
+          .assertion(datetimefield.has({ timestamp: new Date("2014-08-18T09:13:37.512Z").getTime() }))
+      )
+      .child("fillIn date", (test) =>
+        test
+          .step(datetimefield.fillIn(new Date("2014-08-18T09:13:37.512Z")))
+          .assertion(datetimefield.has({ value: "2014-08-18T09:13:37.512" }))
+      )
+      .child("fillIn yyyy-MM-ddThh:mm", (test) =>
+        test.step(datetimefield.fillIn("2014-08-18T09:13")).assertion(datetimefield.has({ value: "2014-08-18T09:13" }))
+      )
+      .child("fillIn yyyy-MM-ddThh:mm:ss", (test) =>
+        test
+          .step(datetimefield.fillIn("2014-08-18T09:13:37"))
+          .assertion(datetimefield.has({ value: "2014-08-18T09:13:37" }))
+      )
+  );

--- a/test/fab.test.tsx
+++ b/test/fab.test.tsx
@@ -1,44 +1,46 @@
 import { test, Page, HTML } from "bigtest";
-import { Fab as Interactor, including } from '../src/index';
-import { Fab as MuiFab, Icon as MuiIcon } from '@material-ui/core';
-import AddIcon from '@material-ui/icons/Add';
-import { render } from './helpers';
+import { Fab as Interactor, including } from "../src/index";
+import { Fab as MuiFab, Icon as MuiIcon } from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
+import { render } from "./helpers";
 
-const Span = HTML.extend('span').selector('span')
+const Span = HTML.extend("span").selector("span");
 
 const fab = Interactor();
 
 export default test("Fab")
   .step(Page.visit("/"))
-  .child("can render a floating action button", (test) => test
-    .step("render fab", async() => {
-      await render(<MuiFab>My Fab</MuiFab>)
-    })
-    .assertion(fab.exists())
-    .assertion(fab.has({ text: "My Fab".toUpperCase()}))
+  .child("can render a floating action button", (test) =>
+    test
+      .step(render(<MuiFab>My Fab</MuiFab>))
+      .assertion(fab.exists())
+      .assertion(fab.has({ text: "My Fab".toUpperCase() }))
   )
-  .child("renders extended floating action button", (test) => test
-    .step("render extended Fab", async() => {
-      await render(<MuiFab variant="extended">My Fab</MuiFab>)
-    })
-    .assertion(fab.has({ className: including('MuiFab-extended')}))
+  .child("renders extended floating action button", (test) =>
+    test
+      .step(render(<MuiFab variant="extended">My Fab</MuiFab>))
+      .assertion(fab.has({ className: including("MuiFab-extended") }))
   )
-  .child("render Icon with children with right classes", (test) => test
-    .step("render Fab with Icon", async() => {
-      const childClassName = 'child-woof';
-      const iconChild = <MuiIcon data-testid="icon" className={childClassName} />;
-      await render(<MuiFab>{iconChild}</MuiFab>);
-    })
-    .assertion(fab.find(Span({ className: including('child-woof')})).exists())
-  )
-  .child("render Fab with only icon and aria-label", (test) => test
-    .step("render Fab", async() => {
-      await render(
-        <MuiFab color="primary" aria-label="add">
-           <AddIcon />
-        </MuiFab>
+  .child("render Icon with children with right classes", (test) =>
+    test
+      .step(
+        render(
+          <MuiFab>
+            <MuiIcon data-testid="icon" className={"child-woof"} />
+          </MuiFab>
+        )
       )
-    })
-    .assertion(fab.has({ ariaLabel: including('add')}))
-    .assertion(fab.has({ svgIcon: true}))
+      .assertion(fab.find(Span({ className: including("child-woof") })).exists())
   )
+  .child("render Fab with only icon and aria-label", (test) =>
+    test
+      .step(
+        render(
+          <MuiFab color="primary" aria-label="add">
+            <AddIcon />
+          </MuiFab>
+        )
+      )
+      .assertion(fab.has({ ariaLabel: including("add") }))
+      .assertion(fab.has({ svgIcon: true }))
+  );

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -1,7 +1,7 @@
 import "date-fns";
 import { bigtestGlobals } from "@bigtest/globals";
 import { render as rtlRender } from "@testing-library/react";
-import { ComponentProps, ComponentType, createElement, ReactElement, useState } from "react";
+import { cloneElement, ComponentProps, ComponentType, createElement, ReactElement, ReactNode, useState } from "react";
 import { StylesProvider, jssPreset } from "@material-ui/core/styles";
 import { create } from "jss";
 import { MuiPickersUtilsProvider } from "@material-ui/pickers";
@@ -44,34 +44,58 @@ export function isHTMLElement<T extends HTMLElementTypes = "">(
   return typeof Constructor == "function" && element instanceof Constructor;
 }
 
+export interface WrapperProps<CT extends ComponentType<any>> {
+  getProps?: Partial<ComponentProps<CT>> | ((props?: Partial<ComponentProps<CT>>) => Partial<ComponentProps<CT>>);
+  props?: Partial<ComponentProps<CT>>;
+  children: (props?: Partial<ComponentProps<CT>>) => ReactElement<ComponentProps<CT>, CT>;
+}
+
+export function getComponentRenderer<CT extends ComponentType<any>>(
+  Component: CT,
+  defaultProps: Partial<ComponentProps<CT>> = {},
+  Wrapper: ComponentType<WrapperProps<CT>> = ({ getProps, children }) =>
+    children(typeof getProps == "function" ? getProps() : getProps)
+) {
+  return (getProps?: WrapperProps<CT>["getProps"]) =>
+    render(
+      <Wrapper getProps={getProps} props={typeof getProps == "function" ? getProps() : getProps}>
+        {(props) => <Component {...({ ...defaultProps, ...props } as ComponentProps<CT>)} />}
+      </Wrapper>
+    );
+}
+
 export function getPickerRenderer<T extends ComponentType<any>>(PickerComponent: T) {
+  const Wrapper = ({ getProps, children }: WrapperProps<T>) => {
+    const props = typeof getProps == "function" ? getProps() : getProps;
+    const initialDate = (props?.date ?? new Date("2014-08-18")) as Date;
+    const [dateValue, _timeValue] = initialDate
+      .toISOString()
+      .replace(/\.\d{3}Z$/, "")
+      .split("T");
+    const [selectedDate, setSelectedDate] = useState<Date | null>(initialDate);
+    return (
+      <MuiPickersUtilsProvider utils={DateFnsUtils}>
+        {/* @ts-expect-error just ignore it */}
+        {children({
+          onChange: setSelectedDate,
+          date: selectedDate,
+          value: selectedDate,
+          id: dateValue,
+          label: dateValue,
+          ...(typeof getProps == "function"
+            ? getProps(
+                // @ts-expect-error
+                { onChange: setSelectedDate }
+              )
+            : getProps),
+        })}
+      </MuiPickersUtilsProvider>
+    );
+  };
+  const renderComponent = getComponentRenderer(PickerComponent, {}, Wrapper);
   return (
     getProps?:
       | Partial<ComponentProps<typeof PickerComponent>>
       | ((onChange?: (date: Date) => void) => Partial<ComponentProps<typeof PickerComponent>>)
-  ) =>
-    render(
-      createElement(() => {
-        const props = typeof getProps == "function" ? getProps() : getProps;
-        const initialDate = (props?.date ?? new Date("2014-08-18")) as Date;
-        const [dateValue, _timeValue] = initialDate
-          .toISOString()
-          .replace(/\.\d{3}Z$/, "")
-          .split("T");
-        const [selectedDate, setSelectedDate] = useState<Date | null>(initialDate);
-        return (
-          <MuiPickersUtilsProvider utils={DateFnsUtils}>
-            {/* @ts-expect-error just ignore type props issues */}
-            <PickerComponent
-              onChange={setSelectedDate}
-              date={selectedDate}
-              value={selectedDate}
-              id={dateValue}
-              label={dateValue}
-              {...(typeof getProps == "function" ? getProps(setSelectedDate) : getProps)}
-            />
-          </MuiPickersUtilsProvider>
-        );
-      })
-    );
+  ) => renderComponent(typeof getProps == "function" ? ({ onChange } = {}) => getProps(onChange) : getProps);
 }

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -8,22 +8,27 @@ import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 
 export function render(element: ReactElement) {
-  let insertion = document.createComment("mui-jss-insertion");
-  let insertionPoint = document.head.insertBefore(insertion, document.head.firstChild);
-  const jss = create({
-    ...jssPreset(),
-    // Define a custom insertion point that JSS will look for when injecting the styles into the DOM.
-    insertionPoint,
-  });
+  return {
+    description: "render",
+    action: () => {
+      let insertion = document.createComment("mui-jss-insertion");
+      let insertionPoint = document.head.insertBefore(insertion, document.head.firstChild);
+      const jss = create({
+        ...jssPreset(),
+        // Define a custom insertion point that JSS will look for when injecting the styles into the DOM.
+        insertionPoint,
+      });
 
-  return rtlRender(
-    <StylesProvider jss={jss} injectFirst>
-      {element}
-    </StylesProvider>,
-    {
-      container: document.body,
-    }
-  );
+      rtlRender(
+        <StylesProvider jss={jss} injectFirst>
+          {element}
+        </StylesProvider>,
+        {
+          container: document.body,
+        }
+      );
+    },
+  };
 }
 
 type HTMLTypes<T> = T extends `HTML${infer C}Element` ? C : never;
@@ -44,7 +49,7 @@ export function getPickerRenderer<T extends ComponentType<any>>(PickerComponent:
     getProps?:
       | Partial<ComponentProps<typeof PickerComponent>>
       | ((onChange?: (date: Date) => void) => Partial<ComponentProps<typeof PickerComponent>>)
-  ) => () =>
+  ) =>
     render(
       createElement(() => {
         const props = typeof getProps == "function" ? getProps() : getProps;

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -1,8 +1,11 @@
+import "date-fns";
 import { bigtestGlobals } from "@bigtest/globals";
 import { render as rtlRender } from "@testing-library/react";
-import { ReactElement } from "react";
+import { ComponentProps, ComponentType, createElement, ReactElement, useState } from "react";
 import { StylesProvider, jssPreset } from "@material-ui/core/styles";
 import { create } from "jss";
+import { MuiPickersUtilsProvider } from "@material-ui/pickers";
+import DateFnsUtils from "@date-io/date-fns";
 
 export function render(element: ReactElement) {
   let insertion = bigtestGlobals.document.createComment("mui-jss-insertion");
@@ -23,9 +26,47 @@ export function render(element: ReactElement) {
   );
 }
 
-export function isHTMLElement(element?: Element | null): element is HTMLElement {
+type HTMLTypes<T> = T extends `HTML${infer C}Element` ? C : never;
+
+type HTMLElementTypes = HTMLTypes<keyof typeof window>;
+
+export function isHTMLElement<T extends HTMLElementTypes = "">(
+  element: unknown | null | undefined,
+  type: T = "" as T
+): element is InstanceType<typeof window[`HTML${T}Element`]> {
+  const { defaultView } = bigtestGlobals.document;
+  const Constructor = (defaultView as any)?.[`HTML${type}Element`];
+  return typeof Constructor == "function" && element instanceof Constructor;
+}
+
+export function getPickerRenderer<T extends ComponentType<any>>(PickerComponent: T) {
   return (
-    element?.ownerDocument.defaultView?.HTMLElement != undefined &&
-    element instanceof element.ownerDocument.defaultView?.HTMLElement
-  );
+    getProps?:
+      | Partial<ComponentProps<typeof PickerComponent>>
+      | ((onChange?: (date: Date) => void) => Partial<ComponentProps<typeof PickerComponent>>)
+  ) => () =>
+    render(
+      createElement(() => {
+        const props = typeof getProps == "function" ? getProps() : getProps;
+        const initialDate = (props?.date ?? new Date("2014-08-18")) as Date;
+        const [dateValue, _timeValue] = initialDate
+          .toISOString()
+          .replace(/\.\d{3}Z$/, "")
+          .split("T");
+        const [selectedDate, setSelectedDate] = useState<Date | null>(initialDate);
+        return (
+          <MuiPickersUtilsProvider utils={DateFnsUtils}>
+            {/* @ts-expect-error just ignore type props issues */}
+            <PickerComponent
+              onChange={setSelectedDate}
+              date={selectedDate}
+              value={selectedDate}
+              id={dateValue}
+              label={dateValue}
+              {...(typeof getProps == "function" ? getProps(setSelectedDate) : getProps)}
+            />
+          </MuiPickersUtilsProvider>
+        );
+      })
+    );
 }

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -8,8 +8,8 @@ import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
 
 export function render(element: ReactElement) {
-  let insertion = bigtestGlobals.document.createComment("mui-jss-insertion");
-  let insertionPoint = bigtestGlobals.document.head.insertBefore(insertion, bigtestGlobals.document.head.firstChild);
+  let insertion = document.createComment("mui-jss-insertion");
+  let insertionPoint = document.head.insertBefore(insertion, document.head.firstChild);
   const jss = create({
     ...jssPreset(),
     // Define a custom insertion point that JSS will look for when injecting the styles into the DOM.
@@ -21,7 +21,7 @@ export function render(element: ReactElement) {
       {element}
     </StylesProvider>,
     {
-      container: bigtestGlobals.document.body,
+      container: document.body,
     }
   );
 }

--- a/test/helpers.tsx
+++ b/test/helpers.tsx
@@ -22,3 +22,10 @@ export function render(element: ReactElement) {
     }
   );
 }
+
+export function isHTMLElement(element?: Element | null): element is HTMLElement {
+  return (
+    element?.ownerDocument.defaultView?.HTMLElement != undefined &&
+    element instanceof element.ownerDocument.defaultView?.HTMLElement
+  );
+}

--- a/test/timefield.test.tsx
+++ b/test/timefield.test.tsx
@@ -1,0 +1,33 @@
+import { Page, test } from "bigtest";
+import { TextField as Component } from "@material-ui/core";
+import { TimeField } from "../src";
+import { getComponentRenderer } from "./helpers";
+
+const renderComponent = getComponentRenderer(Component, { id: "timefield", label: "timefield", type: "time" });
+const timefield = TimeField("timefield");
+
+export default test("TimeField")
+  .step(Page.visit("/"))
+  .child("default", (test) =>
+    test
+      .step(renderComponent())
+      .assertion(timefield.has({ value: "" }))
+      .child("fillIn string", (test) =>
+        test
+          .step(timefield.fillIn("09:13:37.512"))
+          .assertion(timefield.has({ value: "09:13:37.512" }))
+          .assertion(timefield.has({ date: new Date("1970-01-01T09:13:37.512Z") }))
+          .assertion(timefield.has({ timestamp: new Date("1970-01-01T09:13:37.512Z").getTime() }))
+      )
+      .child("fillIn date", (test) =>
+        test
+          .step(timefield.fillIn(new Date("2014-08-18T09:13:37.512Z")))
+          .assertion(timefield.has({ value: "09:13:37.512" }))
+      )
+      .child("fillIn hh:mm", (test) =>
+        test.step(timefield.fillIn("09:13")).assertion(timefield.has({ value: "09:13" }))
+      )
+      .child("fillIn hh:mm:ss", (test) =>
+        test.step(timefield.fillIn("09:13:37")).assertion(timefield.has({ value: "09:13:37" }))
+      )
+  );


### PR DESCRIPTION
PoC API of Date/Time pickers
```ts
const DatePicker = /* HTML of FieldForm */.extend('datepicker')
  .filters({ disabled, readonly, valid })
  .actions({
    setDate({ year?: number, month?: number, day?: number })
    setYear(year: number)
    setMonth(month: number)
    setDay(day: number)
    clear() // Only possible if datepicker is allow to do it, throw an error overwise
    setToday() // The same as 'clear'
    setValue(value: string) // The same. 
  })

const TimePicker = /* HTML of FieldForm */.extend('timepicker')
  .filters({ disabled, readonly, valid, format /* 12/24 hours */ })
  .actions({
    setTime({ hour?: number, minute?: number, second?: number }, format?: 'am' | 'pm')
    setHour(hour: number, format?: 'am' | 'pm')
    setMinute(minute: number)
    setSecond(second: number)
    clear() // Only possible if datepicker is allow to do it, throw an error overwise
    setNow() // The same as 'clear'
    setValue(value: string) // The same
  })
```

I think the all set methods have to throw an error if date is beyond min/max date
And if Datepicker is disabled or is readonly

In some cases, datepicker might be configured to allow select only the year or month or day or any combination of these
So in that case I think we have to throw an error if a user is trying to set something that's not allowed

Progress:
- [x] DatePicker interactor
  - [x] Calendar Interactor
  - [x] Calendar with date utils
  - [x] Calendar tests
  - [ ] DatePicker variants
    - [x] Modal
    - [x] Inline
    - [ ] Static
    - [ ] Views combinations (month/month+year/year)
    - [ ] KeyboardDatePicker
  - [ ] DatePicker with date utils
  - [ ] DatePicker tests (done only for simple variant)
- [ ] TimePicker Interactor
  - [ ] Clock Interactor
- [ ] DateTimePicker Interactor