### PR TITLE
fix: first bump should be a major

### DIFF
--- a/.changes/start-v4.md
+++ b/.changes/start-v4.md
@@ -1,5 +1,5 @@
 ---
-material-ui-interactors: patch
+material-ui-interactors: major
 ---
 
 initial release of v4 alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## \[4.0.0-alpha.0]
+
+- initial release of v4 alpha
+  - [8360cf2](https://github.com/thefrontside/material-ui-interactors/commit/8360cf2936be6722942aa667bba9807f06049922) Setup prerelease mode on 2021-04-23


### PR DESCRIPTION
## Motivation

This was a bit of a unique situation as we were jumping straight into a major version prerelease. The only way to bump to a major (pre)release is with a major bump.

I do think there is an issue with the prerelease logic when everything is a patch bump (deriving prepatch instead of a prerelease), but this change avoids that issue and also best represents what state we want.

We didn't notice this originally because we manually set the version number and it was directly published. We skipped the initial version step.
