### PR TITLE
Configure preview workflow

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -4,8 +4,7 @@
     "javascript": {
       "version": true,
       "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
-      "publish": "npm publish --access public",
-      "errorOnVersionRange": "4.0.0-alpha.100 - 99.x || ^4.4.0-0 || ^5.0.0-0"
+      "publish": "npm publish --access public"
     }
   },
   "packages": {

--- a/.changes/config.json
+++ b/.changes/config.json
@@ -4,7 +4,7 @@
     "javascript": {
       "version": true,
       "getPublishedVersion": "npm view ${ pkgFile.pkg.name } version",
-      "publish": "npm publish --access public"
+      "publish": "npm publish --access public ${ pkg.tag ? '--tag ' + pkg.tag : '' }"
     }
   },
   "packages": {

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,20 @@
+name: covector preview
+on: pull_request
+
+jobs:
+  covector:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: volta-cli/action@v1
+      - run: npm ci --ignore-scripts
+      - run: npm run prepack
+      - name: covector preview
+        uses: ./packages/action
+        id: covector
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          command: preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,10 +16,10 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm run prepack
       - name: covector preview
-        uses: ./packages/action
+        uses: jbolda/covector/packages/action@main
         id: covector
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
           command: preview

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,12 +9,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: "https://registry.npmjs.org"
       - uses: volta-cli/action@v1
       - run: npm ci --ignore-scripts
       - run: npm run prepack
       - name: covector preview
         uses: ./packages/action
         id: covector
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           command: preview


### PR DESCRIPTION
## Motivation

To setup preview-package-publishing workflow. I was asked to setup both preview and release but it looks like the release-publishing workflow has already been setup.

Published [here](https://www.npmjs.com/package/material-ui-interactors) using [this](https://github.com/thefrontside/material-ui-interactors/blob/v4/.github/workflows/covector-version-or-publish.yml) workflow.

## Approach

- New workflow that runs "preview" command
- setup-node step is included in workflow and double checked for `NPM_TOKEN` secret in this repository
- the default label to trigger the preview build is set as `preview`
  - attached the label on this PR to see if it works