### PR TITLE
Publish New Versions

### DIFF
--- a/.changes/pre.json
+++ b/.changes/pre.json
@@ -17,6 +17,7 @@
     ".changes/start-v4.md",
     ".changes/switch.md",
     ".changes/tabs.md",
-    ".changes/textfield.md"
+    ".changes/textfield.md",
+    ".changes/update-deps.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## \[4.0.0-alpha.3]
+
+- Update deps. Migrate from @bigtest/interactor to @interactors/html
+  - [2033117](https://github.com/thefrontside/material-ui-interactors/commit/20331176d9ec67f89bf8bdf979e23236e440ee85) update deps, use @interactors/html on 2021-08-31
+
 ## \[4.0.0-alpha.2]
 
 - Added interactor for [Button](https://material-ui.com/components/buttons/) component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-interactors",
-  "version": "4.0.0-alpha.2",
+  "version": "4.0.0-alpha.3",
   "description": "BigTest interactors for material-ui.com components.",
   "main": "dist/cjs/index.js",
   "browser": "dist/esm/index.js",


### PR DESCRIPTION
# Version Updates

Merging this PR will bump all of the applicable packages based on your change files.




# material-ui-interactors

## [4.0.0-alpha.3]
- Update deps. Migrate from @bigtest/interactor to @interactors/html
  - [2033117](https://github.com/thefrontside/material-ui-interactors/commit/20331176d9ec67f89bf8bdf979e23236e440ee85) update deps, use @interactors/html on 2021-08-31